### PR TITLE
Implement PGN parsing of tag pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [unreleased]
+
+#### Improvements
+* PGN parsing now supports tag pairs (for example `[Event "Name"]`) located at the top of the PGN format, see [Issue #8](https://github.com/chesskit-app/chesskit-swift/issues/8).
+
 # ChessKit 0.4.0
 Released Saturday, April 13, 2024.
 

--- a/Sources/ChessKit/Bitboards/Attacks.swift
+++ b/Sources/ChessKit/Bitboards/Attacks.swift
@@ -310,6 +310,7 @@ struct Magic {
 
 extension [Magic] {
     func attacks(from square: Square, for occupancy: Bitboard) -> Bitboard {
-        self[square.rawValue].attacks(for: occupancy)
+        guard square.rawValue < count else { return 0 }
+        return self[square.rawValue].attacks(for: occupancy)
     }
 }

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -11,7 +11,9 @@ import Foundation
 /// chess game within `ChessKit`. It provides methods for
 /// making moves and publishes the played moves in an observable way.
 ///
-public class Game: Equatable, ObservableObject {
+public class Game: ObservableObject {
+
+    // MARK: - Properties
 
     /// The move tree representing all moves made in the game.
     @Published public private(set) var moves: MoveTree
@@ -20,6 +22,8 @@ public class Game: Equatable, ObservableObject {
 
     /// Contains the tag pairs for this game.
     public var tags: Tags
+
+    // MARK: - Initializer
 
     /// Initialize a game with a starting position.
     ///
@@ -47,6 +51,8 @@ public class Game: Equatable, ObservableObject {
         positions = parsed.positions
         tags = parsed.tags
     }
+
+    // MARK: - Moves
 
     /// Perform the provided move in the game.
     ///
@@ -170,12 +176,19 @@ public class Game: Equatable, ObservableObject {
         PGNParser.convert(game: self)
     }
 
-    // MARK: Equatable
+}
+
+// MARK: - Equatable
+
+extension Game: Equatable {
+
     public static func == (lhs: Game, rhs: Game) -> Bool {
         lhs.moves == rhs.moves && lhs.positions == rhs.positions
     }
 
 }
+
+// MARK: - Tags
 
 extension Game {
 
@@ -194,14 +207,21 @@ extension Game {
         /// corresponding `name`, within brackets.
         public var wrappedValue: String = ""
 
+        /// The projected value of this `Tag` object.
         public var projectedValue: Tag { self }
 
+        /// The PGN representation of this tag.
+        ///
+        /// Formatted as `[Name "Value"]`.
         public var pgn: String {
-            "[\(name) \"\(wrappedValue)\"]"
+            if wrappedValue.isEmpty {
+                return ""
+            } else {
+                return "[\(name) \"\(wrappedValue)\"]"
+            }
         }
 
     }
-
 
     /// Contains the PGN tag pairs for a game.
     public struct Tags {
@@ -310,28 +330,29 @@ extension Game {
         ///
         /// The key will be used as the tag name in the PGN.
         public var other: [String: String] = [:]
-
-        public init() {
-
-        }
         
+        /// Initializes a `Game.Tags` object with the provided
+        /// values.
+        ///
+        /// For initialization purposes, all values are optional,
+        /// and any omitted values will be set to empty strings.
         public init(
-            event: String,
-            site: String,
-            date: String,
-            round: String,
-            white: String,
-            black: String,
-            result: String,
-            annotator: String,
-            plyCount: String,
-            timeControl: String,
-            time: String,
-            termination: String,
-            mode: String,
-            fen: String,
-            setUp: String,
-            other: [String : String]
+            event: String = "",
+            site: String = "",
+            date: String = "",
+            round: String = "",
+            white: String = "",
+            black: String = "",
+            result: String = "",
+            annotator: String = "",
+            plyCount: String = "",
+            timeControl: String = "",
+            time: String = "",
+            termination: String = "",
+            mode: String = "",
+            fen: String = "",
+            setUp: String = "",
+            other: [String : String] = [:]
         ) {
             self.event = event
             self.site = site

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -18,14 +18,18 @@ public class Game: Equatable, ObservableObject {
     /// A dictionary of every position in the game, keyed by move index.
     public private(set) var positions: [MoveTree.Index: Position]
 
+    /// Contains the tag pairs for this game.
+    public var tags: Tags
+
     /// Initialize a game with a starting position.
     ///
     /// - parameter position: The starting position of the game.
     /// Defaults to the starting position.
     ///
-    public init(startingWith position: Position = .standard) {
+    public init(startingWith position: Position = .standard, tags: Tags? = nil) {
         moves = MoveTree()
         positions = [.minimum: position]
+        self.tags = tags ?? .init()
     }
 
     /// Initialize a game with a PGN string.
@@ -41,6 +45,7 @@ public class Game: Equatable, ObservableObject {
 
         moves = parsed.moves
         positions = parsed.positions
+        tags = parsed.tags
     }
 
     /// Perform the provided move in the game.
@@ -168,6 +173,183 @@ public class Game: Equatable, ObservableObject {
     // MARK: Equatable
     public static func == (lhs: Game, rhs: Game) -> Bool {
         lhs.moves == rhs.moves && lhs.positions == rhs.positions
+    }
+
+}
+
+extension Game {
+
+    /// Denotes a PGN tag pair.
+    @propertyWrapper
+    public struct Tag {
+
+        /// The name of the tag pair.
+        ///
+        /// Used as the key in a PGN tag pair.
+        var name: String
+
+        /// The value of the tag pair.
+        ///
+        /// Appears at the top of the PGN after the
+        /// corresponding `name`, within brackets.
+        public var wrappedValue: String = ""
+
+        public var projectedValue: Tag { self }
+
+        public var pgn: String {
+            "[\(name) \"\(wrappedValue)\"]"
+        }
+
+    }
+
+
+    /// Contains the PGN tag pairs for a game.
+    public struct Tags {
+
+        /// Whether or not all the standard mandatory tags for 
+        /// PGN archival are set.
+        ///
+        /// These include `event`, `site`, `date`, `round`,
+        /// `white`, `black`, and `result` (known as the "Seven Tag Roster").
+        public var isValid: Bool {
+            [event, site, date, round, white, black, result]
+                .allSatisfy { !$0.isEmpty }
+        }
+
+        /// Name of the tournament or match event.
+        ///
+        /// Example: `"F/S Return Match"`
+        @Tag(name: "Event")
+        public var event: String
+
+        /// Location of the event.
+        ///
+        /// Example: `"Belgrade, Serbia JUG"`
+        ///
+        /// The format for this value is "City, Region COUNTRY",
+        /// where "COUNTRY" is the three-letter International Olympic Committee
+        /// code for the country.
+        ///
+        /// Although not part of the specification, some online chess platforms 
+        /// will include a URL or website as the site value.
+        @Tag(name: "Site")
+        public var site: String
+
+        /// Starting date of the game, in YYYY.MM.DD format.
+        ///
+        /// Example: `"1992.11.04"`
+        ///
+        /// `"??"` is used for unknown values.
+        @Tag(name: "Date")
+        public var date: String
+
+        /// Playing round ordinal of the game within the event.
+        ///
+        /// Example `"29"`
+        @Tag(name: "Round")
+        public var round: String
+
+        /// Player of the white pieces, in "Lastname, Firstname" format.
+        ///
+        /// Example: `"Fischer, Robert J."`
+        @Tag(name: "White")
+        public var white: String
+
+        /// Player of the black pieces, in "Lastname, Firstname" format.
+        ///
+        /// Example: `"Spassky, Boris V."`
+        @Tag(name: "Black")
+        public var black: String
+
+        /// Result of the game. 
+        ///
+        /// Example: `"1/2-1/2"`
+        ///
+        /// It is recorded as White score, dash, then Black score, or `*` (other, e.g., the game is ongoing).
+        @Tag(name: "Result")
+        public var result: String
+
+        /// The person providing notes to the game. (optional)
+        @Tag(name: "Annotator")
+        public var annotator: String
+
+        /// String value denoting the total number of half-moves played. (optional)
+        @Tag(name: "PlyCount")
+        public var plyCount: String
+
+        /// e.g. 40/7200:3600 (moves per seconds: sudden death seconds) (optional)
+        @Tag(name: "TimeControl")
+        public var timeControl: String
+
+        /// Time the game started, in HH:MM:SS format, in local clock time. (optional)
+        @Tag(name: "Time")
+        public var time: String
+
+        /// Gives more details about the termination of the game. It may be abandoned, adjudication (result determined by third-party adjudication), death, emergency, normal, rules infraction, time forfeit, or unterminated. (optional)
+        @Tag(name: "Termination")
+        public var termination: String
+
+        /// The mode of play used for the game. (optional)
+        ///
+        /// `"OTB"` (over-the-board) or `"ICS"` (Internet Chess Server)
+        @Tag(name: "Mode")
+        public var mode: String
+
+        /// The initial position of the chessboard, in Forsyth–Edwards Notation. (optional)
+        ///
+        /// This is used to record partial games (starting at some initial position). It is also necessary for chess variants such as Chess960, where the initial position is not always the same as traditional chess.
+        ///
+        /// If a FEN tag is used, a separate tag pair SetUp must also appear and have its value set to 1.
+        @Tag(name: "FEN")
+        public var fen: String
+
+        @Tag(name: "SetUp")
+        public var setUp: String
+
+        /// Extra custom tags.
+        ///
+        /// The key will be used as the tag name in the PGN.
+        public var other: [String: String] = [:]
+
+        public init() {
+
+        }
+        
+        public init(
+            event: String,
+            site: String,
+            date: String,
+            round: String,
+            white: String,
+            black: String,
+            result: String,
+            annotator: String,
+            plyCount: String,
+            timeControl: String,
+            time: String,
+            termination: String,
+            mode: String,
+            fen: String,
+            setUp: String,
+            other: [String : String]
+        ) {
+            self.event = event
+            self.site = site
+            self.date = date
+            self.round = round
+            self.white = white
+            self.black = black
+            self.result = result
+            self.annotator = annotator
+            self.plyCount = plyCount
+            self.timeControl = timeControl
+            self.time = time
+            self.termination = termination
+            self.mode = mode
+            self.fen = fen
+            self.setUp = setUp
+            self.other = other
+        }
     }
 
 }

--- a/Sources/ChessKit/Parsers/PGNParser+Regex.swift
+++ b/Sources/ChessKit/Parsers/PGNParser+Regex.swift
@@ -7,6 +7,10 @@ extension PGNParser {
 
     /// Contains useful regex strings for PGN parsing.
     struct Regex {
+        // tag pair components
+        static let tags = #"\[[^\]]+\]"#
+        static let tagPair = #"\[([^"]+?)\s"([^"]+)"\]"#
+
         // move pair components
         static let number = #"\d{1,}\.{1,3}"#
         static let castle = #"[Oo0]-[Oo0](-[Oo0])"#

--- a/Sources/ChessKit/Parsers/PGNParser.swift
+++ b/Sources/ChessKit/Parsers/PGNParser.swift
@@ -236,23 +236,26 @@ public class PGNParser {
 
         // tags
 
-        pgn += game.tags.$event.pgn + "\n"
-        pgn += game.tags.$site.pgn + "\n"
-        pgn += game.tags.$date.pgn + "\n"
-        pgn += game.tags.$round.pgn + "\n"
-        pgn += game.tags.$white.pgn + "\n"
-        pgn += game.tags.$black.pgn + "\n"
-        pgn += game.tags.$result.pgn + "\n"
-        pgn += game.tags.$annotator.pgn + "\n"
-        pgn += game.tags.$plyCount.pgn + "\n"
-        pgn += game.tags.$timeControl.pgn + "\n"
-        pgn += game.tags.$time.pgn + "\n"
-        pgn += game.tags.$termination.pgn + "\n"
-        pgn += game.tags.$mode.pgn + "\n"
-        pgn += game.tags.$fen.pgn + "\n"
-        pgn += game.tags.$setUp.pgn + "\n"
+        [game.tags.$event,
+         game.tags.$site,
+         game.tags.$date,
+         game.tags.$round,
+         game.tags.$white,
+         game.tags.$black,
+         game.tags.$result,
+         game.tags.$annotator,
+         game.tags.$plyCount,
+         game.tags.$timeControl,
+         game.tags.$time,
+         game.tags.$termination,
+         game.tags.$mode,
+         game.tags.$fen,
+         game.tags.$setUp]
+            .map(\.pgn)
+            .filter { !$0.isEmpty }
+            .forEach { pgn += $0 + "\n" }
 
-        game.tags.other.forEach { key, value in
+        game.tags.other.sorted(by: <).forEach { key, value in
             pgn += "[\(key) \"\(value)\"]\n"
         }
 

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -334,8 +334,6 @@ class BoardTests: XCTestCase {
         ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
         ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
         """)
-
-        print(Board(position: Position(fen: "rnbqkbnr/pp1ppppp/8/2p5/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2")!))
     }
 
 }

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -222,6 +222,37 @@ class GameTests: XCTestCase {
         XCTAssertEqual(game.pgn, pgn)
     }
 
+    func testValidTagPairs() {
+        let pgn =
+        """
+        [Event "Test Event"]
+        [Site "Barrow, Alaska USA"]
+        [Date "2000.01.01"]
+        [Round "5"]
+        [White "Player One"]
+        [Black "Player Two"]
+        [Result "1-0"]
+
+        1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4
+        """
+
+        let game = Game(pgn: pgn)!
+        XCTAssertTrue(game.tags.isValid)
+    }
+
+    func testInValidTagPairs() {
+        let pgn =
+        """
+        [Event "Test Event"]
+
+        1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4
+        """
+
+        let game = Game(pgn: pgn)!
+        XCTAssertFalse(game.tags.isValid)
+        XCTAssertTrue(game.tags.$site.pgn.isEmpty)
+    }
+
 }
 
 extension GameTests {

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -213,7 +213,7 @@ class GameTests: XCTestCase {
         [Mode "OTB"]
         [FEN "\(Position.standard.fen)"]
         [SetUp "1"]
-        [TestKey1 "Test Value 2"]
+        [TestKey1 "Test Value 1"]
         [TestKey2 "Test Value 2"]
 
         1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4
@@ -243,7 +243,7 @@ extension GameTests {
         fen: Position.standard.fen,
         setUp: "1",
         other: [
-            "TestKey1": "Test Value 2",
+            "TestKey1": "Test Value 1",
             "TestKey2": "Test Value 2"
         ]
     )

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -22,6 +22,8 @@ class GameTests: XCTestCase {
     // MARK: - Setup
 
     override func setUp() {
+        game.tags = Self.mockTags
+
         game.make(moves: ["e4", "e5", "Nf3", "Nc6", "Bc4"], from: .minimum)
 
         // add 2. Nc3 ... variation to 2. Nf3
@@ -85,7 +87,7 @@ class GameTests: XCTestCase {
         game.moves[f5Index]?.comment = "Comment test"
 
         XCTAssertEqual(
-            PGNParser.convert(game: game),
+            PGNParser.convert(game: game).split(separator: "\n").last,
             "1. e4 e5 2. Nf3 (2. Nc3 $3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 {Comment test} 3. exf5) 3. Bc4"
         )
     }
@@ -194,9 +196,56 @@ class GameTests: XCTestCase {
     }
 
     func testPGN() {
-        let pgn = "1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4"
+        let pgn = 
+        """
+        [Event "Test Event"]
+        [Site "Barrow, Alaska USA"]
+        [Date "2000.01.01"]
+        [Round "5"]
+        [White "Player One"]
+        [Black "Player Two"]
+        [Result "1-0"]
+        [Annotator "Annotator"]
+        [PlyCount "15"]
+        [TimeControl "40/7200:3600"]
+        [Time "12:00"]
+        [Termination "abandoned"]
+        [Mode "OTB"]
+        [FEN "\(Position.standard.fen)"]
+        [SetUp "1"]
+        [TestKey1 "Test Value 2"]
+        [TestKey2 "Test Value 2"]
+
+        1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4
+        """
 
         XCTAssertEqual(game.pgn, pgn)
     }
+
+}
+
+extension GameTests {
+
+    private static let mockTags = Game.Tags(
+        event: "Test Event",
+        site: "Barrow, Alaska USA",
+        date: "2000.01.01",
+        round: "5",
+        white: "Player One",
+        black: "Player Two",
+        result: "1-0",
+        annotator: "Annotator",
+        plyCount: "15",
+        timeControl: "40/7200:3600",
+        time: "12:00",
+        termination: "abandoned",
+        mode: "OTB",
+        fen: Position.standard.fen,
+        setUp: "1",
+        other: [
+            "TestKey1": "Test Value 2",
+            "TestKey2": "Test Value 2"
+        ]
+    )
 
 }

--- a/Tests/ChessKitTests/Parsers/PGNParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/PGNParserTests.swift
@@ -8,23 +8,48 @@ import XCTest
 
 class PGNParserTests: XCTestCase {
 
-    func testPGNParsing() {
-        let pgn =
-            """
-            1. e4 $4 e5 2. Nf3 Nc6 3. Bb5 a6 {This opening is called the Ruy Lopez.}
-            4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7
-            11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5
-            Nxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6
-            23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5
-            hxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5
-            35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6
-            Nf2 42. g4 Bd3 43. Re6 1/2-1/2
-            """
+    private let pgn =
+        """
+        [Event "F/S Return Match"]
+        [Site "Belgrade, Serbia JUG"]
+        [Date "1992.11.04"]
+        [Round "29"]
+        [White "Fischer, Robert J."]
+        [Black "Spassky, Boris V."]
+        [Result "1/2-1/2"]
 
+        1. e4 $4 e5 2. Nf3 Nc6 3. Bb5 a6 {This opening is called the Ruy Lopez.}
+        4. Ba4 Nf6 5. O-O Be7 6. Re1 b5 7. Bb3 d6 8. c3 O-O 9. h3 Nb8 10. d4 Nbd7
+        11. c4 c6 12. cxb5 axb5 13. Nc3 Bb7 14. Bg5 b4 15. Nb1 h6 16. Bh4 c5 17. dxe5
+        Nxe4 18. Bxe7 Qxe7 19. exd6 Qf6 20. Nbd2 Nxd6 21. Nc4 Nxc4 22. Bxc4 Nb6
+        23. Ne5 Rae8 24. Bxf7+ Rxf7 25. Nxf7 Rxe1+ 26. Qxe1 Kxf7 27. Qe3 Qg5 28. Qxg5
+        hxg5 29. b3 Ke6 30. a3 Kd6 31. axb4 cxb4 32. Ra5 Nd5 33. f3 Bc8 34. Kf2 Bf5
+        35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6
+        Nf2 42. g4 Bd3 43. Re6 1/2-1/2
+        """
+
+    func testGameFromPGN() {
         let game = PGNParser.parse(game: pgn)
         let gameFromPGN = Game(pgn: pgn)
 
         XCTAssertEqual(game, gameFromPGN)
+    }
+
+    func testTagParsing() {
+        let game = PGNParser.parse(game: pgn)
+
+        // tags
+        XCTAssertEqual(game?.tags.event, "F/S Return Match")
+        XCTAssertEqual(game?.tags.site, "Belgrade, Serbia JUG")
+        XCTAssertEqual(game?.tags.date, "1992.11.04")
+        XCTAssertEqual(game?.tags.round, "29")
+        XCTAssertEqual(game?.tags.white, "Fischer, Robert J.")
+        XCTAssertEqual(game?.tags.black, "Spassky, Boris V.")
+        XCTAssertEqual(game?.tags.result, "1/2-1/2")
+    }
+
+    func testMoveTextParsing() {
+        let game = PGNParser.parse(game: pgn)
 
         // starting position + 85 ply
         XCTAssertEqual(game?.positions.keys.count, 86)


### PR DESCRIPTION
* Added support for tag pairs in `PGNParser` and therefore `Game(pgn:)`.
* Utilities new public `Game.Tags` struct with support for mandatory and other common tags, as well as any custom tags.

closes #8 