### PR TITLE
Update version number in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Swift package for efficiently implementing chess logic.
 
 * Add a package dependency to your Xcode project or Swift Package:
 ``` swift
-.package(url: "https://github.com/chesskit-app/chesskit-swift", from: "0.5.0")
+.package(url: "https://github.com/chesskit-app/chesskit-swift", from: "0.6.0")
 ```
 
 * Next you can import `ChessKit` to use it in your Swift code:


### PR DESCRIPTION
When installing at the weekend for a hooby protect of mine I noticed that the version number in the installation instructions was one behind.