### PR TITLE
Add starting index and position to `Game`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [unreleased]
+
+* Add `startingIndex` and `startingPosition` to `Game`.
+  * `startingIndex` takes into account the `sideToMove` of `startingPosition`.
+
 # ChessKit 0.6.0
 Released Friday, April 19, 2024.
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@
 
 A Swift package for efficiently implementing chess logic.
 
+For a related Swift package that contains chess engines such as [Stockfish](https://stockfishchess.org), see [chesskit-engine](https://github.com/chesskit-app/chesskit-engine).
+
 ## Usage
 
-* Add a package dependency to your Xcode project or Swift Package:
-``` swift
-.package(url: "https://github.com/chesskit-app/chesskit-swift", from: "0.5.0")
-```
+1. Add `chesskit-swift` as a dependency
+	* In an [app built in Xcode](https://developer.apple.com/documentation/xcode/adding-package-dependencies-to-your-app),
+	* or [as a dependency to another Swift Package](https://www.swift.org/documentation/package-manager/#importing-dependencies).
 
-* Next you can import `ChessKit` to use it in your Swift code:
+2. Next, import `ChessKit` to use it in Swift code:
 ``` swift
 import ChessKit
 
@@ -31,6 +32,9 @@ import ChessKit
     * `Game`
     * Special moves (castling, en passant)
 * Move validation
+    * Implemented using highly performant `UInt64` [bitboards](https://www.chessprogramming.org/Bitboards).
+* Pawn promotion handling
+* Game states (check, stalemate, checkmate, etc.)
 * Chess notation string parsing
     * PGN
     * FEN
@@ -72,13 +76,13 @@ board.move(pieceAt: .e2, to: .e4)           // move pawn at e2 to e4
 * Check move legality
 ``` swift
 let board = Board()
-print(board.canMove(pieceAt: .a1, to: .a8)) // returns false
+print(board.canMove(pieceAt: .a1, to: .a8)) // false
 ```
 
 * Check legal moves
 ``` swift
 let board = Board()
-print(board.legalMoves(forPieceAt: .e2))    // returns [.e3, .e4]
+print(board.legalMoves(forPieceAt: .e2))    // [.e3, .e4]
 ```
 
 * Parse [FEN](https://en.wikipedia.org/wiki/Forsyth–Edwards_Notation) into a `Position` object
@@ -105,10 +109,6 @@ let move = Move(san: "e4", in: .standard)
 // convert Move to SAN string
 let sanString = move.san
 ```
-
-## Author
-
-[@pdil](https://github.com/pdil)
 
 ## License
 

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -17,11 +17,17 @@ public class Game: ObservableObject {
 
     /// The move tree representing all moves made in the game.
     @Published public private(set) var moves: MoveTree
+    /// The move tree index of the starting position in the game.
+    public private(set) var startingIndex: MoveTree.Index
     /// A dictionary of every position in the game, keyed by move index.
     public private(set) var positions: [MoveTree.Index: Position]
-
     /// Contains the tag pairs for this game.
     public var tags: Tags
+
+    /// The starting position of the game.
+    public var startingPosition: Position? {
+        positions[startingIndex]
+    }
 
     // MARK: - Initializer
 
@@ -32,8 +38,11 @@ public class Game: ObservableObject {
     ///
     public init(startingWith position: Position = .standard, tags: Tags? = nil) {
         moves = MoveTree()
-        positions = [.minimum: position]
+        startingIndex = position.sideToMove == .white ? .minimum : .minimum.next
+        positions = [startingIndex: position]
         self.tags = tags ?? .init()
+
+        moves.minimumIndex = startingIndex
     }
 
     /// Initialize a game with a PGN string.
@@ -48,6 +57,7 @@ public class Game: ObservableObject {
         }
 
         moves = parsed.moves
+        startingIndex = .minimum
         positions = parsed.positions
         tags = parsed.tags
     }

--- a/Sources/ChessKit/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree.swift
@@ -9,6 +9,8 @@
 /// provides index-based access for any element in the tree.
 public struct MoveTree {
 
+    var minimumIndex: Index = .minimum
+
     /// Dictionary representation of the tree for faster access.
     private var dictionary: [Index: Node] = [:]
     /// The root node of the tree.
@@ -63,7 +65,7 @@ public struct MoveTree {
         let newNode = Node(move: move)
 
         guard let root, let moveIndex else {
-            let index = Index.minimum.next
+            let index = minimumIndex.next
 
             newNode.index = index
             self.root = newNode
@@ -94,8 +96,8 @@ public struct MoveTree {
 
     /// Returns the index of the previous move given an `index`.
     public func previousIndex(for index: Index) -> Index? {
-        if index == .minimum.next {
-            return .minimum
+        if index == minimumIndex {
+            return minimumIndex
         } else {
             return dictionary[index]?.previous?.index
         }
@@ -103,8 +105,8 @@ public struct MoveTree {
 
     /// Returns the index of the next move given an `index`.
     public func nextIndex(for index: Index) -> Index? {
-        if index == .minimum {
-            return dictionary[.minimum.next]?.index
+        if index == minimumIndex {
+            return dictionary[minimumIndex.next]?.index
         } else {
             return dictionary[index]?.next?.index
         }
@@ -114,7 +116,7 @@ public struct MoveTree {
     /// move contained at `index`.
     public func nextIndex(containing move: Move, for index: Index) -> Index? {
         guard let node = dictionary[index] else {
-            if index == .minimum, let root, root.move == move {
+            if index == minimumIndex, let root, root.move == move {
                 return root.index
             } else {
                 return nil

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -64,6 +64,15 @@ class GameTests: XCTestCase {
             .init(number: 1, color: .white, variation: 0)
         )
         XCTAssertEqual(game2.startingPosition, .init(fen: fen)!)
+        game2.make(move: "O-O", from: game2.startingIndex)
+        XCTAssertEqual(
+            game2.moves.nextIndex(for: game2.moves.minimumIndex),
+            .init(number: 1, color: .black, variation: 0)
+        )
+        XCTAssertEqual(
+            game2.moves.move(at: .init(number: 1, color: .black, variation: 0)),
+            .init(san: "O-O", position: .init(fen: fen)!)
+        )
     }
 
     func testMakeMoves() {
@@ -98,6 +107,9 @@ class GameTests: XCTestCase {
             ),
             nf3Index
         )
+
+        XCTAssertEqual(game.moves.previousIndex(for: .minimum), .minimum)
+        XCTAssertEqual(game.moves.nextIndex(for: nc3Index), nf6Index)
     }
 
     func testMoveAnnotation() {

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -48,6 +48,24 @@ class GameTests: XCTestCase {
 
     // MARK: - Test cases
 
+    func testStartingPosition() {
+        let game1 = Game(startingWith: .standard)
+        XCTAssertEqual(
+            game1.startingIndex,
+            .init(number: 0, color: .black, variation: 0)
+        )
+        XCTAssertEqual(game1.startingPosition, .standard)
+
+        let fen = "r1bqkb1r/pp1ppppp/2n2n2/8/2B1P3/2N2N2/PP3PPP/R1BQK2R b KQkq - 4 6"
+        let game2 = Game(startingWith: .init(fen: fen)!)
+
+        XCTAssertEqual(
+            game2.startingIndex,
+            .init(number: 1, color: .white, variation: 0)
+        )
+        XCTAssertEqual(game2.startingPosition, .init(fen: fen)!)
+    }
+
     func testMakeMoves() {
         XCTAssertFalse(game.moves.isEmpty)
         XCTAssertEqual(game.moves[.init(number: 1, color: .white)]?.san, "e4")


### PR DESCRIPTION
* Added `startingIndex` and `startingPosition` to `Game`
* If the starting position provided to the `Game` initializer represents one with which black is to move next, the `startingIndex` will be adjusted according.
* `MoveTree` has also been updated to take this starting index into account.