### PR TITLE
Resolve rare en passant bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # [unreleased]
 
+#### Improvements
 * Add `startingIndex` and `startingPosition` to `Game`.
   * `startingIndex` takes into account the `sideToMove` of `startingPosition`.
+
+#### Bug Fixes
+* Fix rare en passant issue that could allow the king to be left in check, see [Issue #18](https://github.com/chesskit-app/chesskit-swift/issues/18).
 
 # ChessKit 0.6.0
 Released Friday, April 19, 2024.

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -321,15 +321,18 @@ public struct Board {
     /// 
     private func validate(moveFor piece: Piece, to square: Square) -> Bool {
         // attempt move in test set
-        //
-        // to-do: prune pseudo legal moves for sliding pieces
-        // based on diagonals, lines, etc if pinned
         var testSet = set
         testSet.remove(piece)
 
         var movedPiece = piece
         movedPiece.square = square
         testSet.add(movedPiece)
+
+        if let enPassant = position.enPassant {
+            if enPassant.canBeCaptured(by: piece) && enPassant.captureSquare == square {
+                testSet.remove(enPassant.pawn)
+            }
+        }
 
         return !isKingInCheck(piece.color, set: testSet)
     }

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -45,6 +45,12 @@ class BoardTests: XCTestCase {
         XCTAssertEqual(move.result, .capture(ep.pawn))
     }
 
+    func testIllegalEnPassant() {
+        // fen position contains illegal en passant move
+        let board = Board(position: .init(fen: "1nbqkbnr/1pp1pppp/8/r1Pp3K/p7/5P2/PP1PP1PP/RNBQ1BNR w k d6 0 8")!)
+        XCTAssertFalse(board.canMove(pieceAt: .c5, to: .d6))
+    }
+
     func testCastling() {
         var board = Board(position: .castling)
         XCTAssertTrue(board.position.legalCastlings.contains(.bK))


### PR DESCRIPTION
* Added en passant step to move validation to prevent en passant moves that leave the king in check.
* For an example of such a position see: `1nbqkbnr/1pp1pppp/8/r1Pp3K/p7/5P2/PP1PP1PP/RNBQ1BNR w k d6 0 8`

fixes #18