### PR TITLE
Fix move tree previous index calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# [unreleased]
+
+* Fix `MoveTree.previousIndex(for:)` when provided index is one after `minimumIndex`.
+
 # ChessKit 0.7.0
 Released Monday, April 29, 2024.
 

--- a/Sources/ChessKit/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree.swift
@@ -96,7 +96,7 @@ public struct MoveTree {
 
     /// Returns the index of the previous move given an `index`.
     public func previousIndex(for index: Index) -> Index? {
-        if index == minimumIndex {
+        if index == minimumIndex.next {
             return minimumIndex
         } else {
             return dictionary[index]?.previous?.index

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -108,7 +108,7 @@ class GameTests: XCTestCase {
             nf3Index
         )
 
-        XCTAssertEqual(game.moves.previousIndex(for: .minimum), .minimum)
+        XCTAssertEqual(game.moves.previousIndex(for: .minimum.next), .minimum)
         XCTAssertEqual(game.moves.nextIndex(for: nc3Index), nf6Index)
     }
 


### PR DESCRIPTION
* Fix issue in `MoveTree.previousIndex(for:)` when provided index is equal to `minimumIndex.next`.
* Regression occurred after introduction of `minimumIndex` property in `MoveTree`.