### PR TITLE
Fixed insufficient material logic

### DIFF
--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -189,17 +189,13 @@ public struct Position: Equatable {
                 // 1 bishop or 1 knight, i.e. insufficient material
                 return true
             } else {
-                // check if no knights and all bishops of the same
-                // color are on the same color square, i.e. insufficient material
-                let allWBLight = set.B & .dark == 0 // all white bishops on light squares
-                let allWBDark = set.B & .light == 0 // all white bishops on dark squares
-                let allBBLight = set.b & .dark == 0 // all black bishops on light squares
-                let allBBDark = set.b & .light == 0 // all black bishops on dark squares
+                // check if no knights and all bishops
+                // are on the same color square, i.e. insufficient material
+                let allBLight = set.bishops & .dark == 0 // all bishops on light squares
+                let allBDark = set.bishops & .light == 0 // all bishops on dark squares
 
-                return set.knights == 0 && (
-                    (allWBLight && (allBBDark || allBBLight))
-                    || (allWBDark && (allBBDark || allBBLight))
-                )
+                return set.knights == 0
+                && (allBLight || allBDark)
             }
         } else {
             // not insufficient material if pawns, rooks, or queens

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -197,7 +197,7 @@ class BoardTests: XCTestCase {
         let board4 = Board(position: .init(fen: fen4)!)
 
         XCTAssertFalse(board2.position.hasInsufficientMaterial)
-        XCTAssertTrue(board3.position.hasInsufficientMaterial)
+        XCTAssertFalse(board3.position.hasInsufficientMaterial)
         XCTAssertTrue(board4.position.hasInsufficientMaterial)
 
         // before and after king takes Queen

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -185,28 +185,22 @@ class BoardTests: XCTestCase {
         }
         
         // opposite color bishops VS same color bishops
-        let fen2 = "k5B1/b6P/8/8/8/8/8/K7 w - - 0 1"
-        let fen3 = "k5B1/b7/1b6/8/8/8/8/K7 w - - 0 1"
-        let fen4 = "k5B1/1b6/2b5/8/8/8/8/K7 w - - 0 1"
+        let fen2 = "k5B1/b7/1b6/8/8/8/8/K7 w - - 0 1"
+        let fen3 = "k5B1/1b6/2b5/8/8/8/8/K7 w - - 0 1"
 
-        var board2 = Board(position: .init(fen: fen2)!)
-        let move2 = board2.move(pieceAt: .h7, to: .h8)!
-        board2.completePromotion(of: move2 , to: .bishop)
-
+        let board2 = Board(position: .init(fen: fen2)!)
         let board3 = Board(position: .init(fen: fen3)!)
-        let board4 = Board(position: .init(fen: fen4)!)
 
         XCTAssertFalse(board2.position.hasInsufficientMaterial)
-        XCTAssertFalse(board3.position.hasInsufficientMaterial)
-        XCTAssertTrue(board4.position.hasInsufficientMaterial)
+        XCTAssertTrue(board3.position.hasInsufficientMaterial)
 
         // before and after king takes Queen
-        let fen5 = "k7/1Q6/8/8/8/8/8/K7 w - - 0 1"
-        var board5 = Board(position: .init(fen: fen5)!)
+        let fen4 = "k7/1Q6/8/8/8/8/8/K7 w - - 0 1"
+        var board4 = Board(position: .init(fen: fen4)!)
 
-        XCTAssertFalse(board5.position.hasInsufficientMaterial)
-        board5.move(pieceAt: .a8, to: .b7)
-        XCTAssertTrue(board5.position.hasInsufficientMaterial)
+        XCTAssertFalse(board4.position.hasInsufficientMaterial)
+        board4.move(pieceAt: .a8, to: .b7)
+        XCTAssertTrue(board4.position.hasInsufficientMaterial)
     }
     
     func testLegalMovesForNonexistentPiece() {

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -18,7 +18,7 @@ extension Position {
 
     static let fiftyMove = Position(fen: "8/5k2/3p4/1p1Pp2p/pP2Pp1P/P4P1K/8/8 b - - 99 50")!
 
-    static let insufficientMaterial = Position(fen: "k7/1b5P/8/8/8/8/8/K7 w - - 0 1")!
+    static let insufficientMaterial = Position(fen: "k7/b6P/8/8/8/8/8/K7 w - - 0 1")!
 }
 
 class MockBoardDelegate: BoardDelegate {


### PR DESCRIPTION
I just noticed that after your refactoring the logic to check if there is a draw by insufficient material is wrong. If there are no knights and the pieces are >= 4, the draw can happen only if **<u>all the bishops</u>** on the board are on the same color square.
If all the white bishops are on the light squares and all the black bishops are on the dark squares it’s still not a draw. Let me show you:

<img width="573" alt="Screenshot 2024-05-10 at 20 34 16" src="https://github.com/chesskit-app/chesskit-swift/assets/144626322/9360a9a1-2278-4676-a56f-9426afb59652">

In this position black can make the move bishop a2, to which white can answer with bishop d5 checkmate.

```swift

// white has all bishops on light squares while black has all bishops on dark squares

let allWBLight = set.B & .dark == 0 // true
let allWBDark = set.B & .light == 0 // false
let allBBLight = set.b & .dark == 0 // false
let allBBDark = set.b & .light == 0 // true

(allWBLight && (allBBDark || allBBLight)) || (allWBDark && (allBBDark || allBBLight)) ->
(true && (true || false)) || (false && (true || false)) -> true //wrong

// as we just saw in the previous example this can't be true since it's not a forced draw

```

In addition to what I just said, there is also another problem. Let's say that white has 2...N bishops while black has none. The variables `let allBBDark = set.b & .light == 0` and `let allBBLight = set.b & .light == 0` will be true, which is not correct.

I hope everything is clear now. Let me know if you have any other doubt 😄 
