### PR TITLE
Improve comment formatting and other small miscellaneous changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [unreleased]
+
+* Removed `CustomDebugStringConvertible` conformance from `Bitboard` to avoid affecting all `UInt64` debug prints.
+  * To print the string representation of `Bitboard` use `Bitboard.chessString()`.
+
 # ChessKit 0.8.0
 Released Friday, June 7, 2024.
 

--- a/Sources/ChessKit/Bitboards/Attacks.swift
+++ b/Sources/ChessKit/Bitboards/Attacks.swift
@@ -5,7 +5,6 @@
 
 /// Stores pre-generated pseudo-legal attack bitboards
 /// for non-pawn piece types.
-///
 struct Attacks {
 
     /// Cached king attacks, the dictionary key
@@ -141,7 +140,6 @@ struct Attacks {
     ///
     /// Uses a similar techique as Stockfish (see [`Stockfish/init_magics`](https://github.com/official-stockfish/Stockfish/blob/0716b845fdef8a20102b07eaec074b8da8162523/src/bitboard.cpp#L139)) except with hardcoded magics rather than
     /// seeded random generation.
-    ///
     private static func createMagics(for kind: Piece.Kind) {
         guard let magicNumbers = magicNumbers[kind] else { return }
 
@@ -280,7 +278,6 @@ struct Attacks {
 
 /// Stores the magic factors and attacks for a given piece
 /// type (bishop or rook) and square (a1-h8).
-///
 struct Magic {
     /// The magic number used to compute the hash key.
     fileprivate var magic: Bitboard

--- a/Sources/ChessKit/Bitboards/Bitboard.swift
+++ b/Sources/ChessKit/Bitboards/Bitboard.swift
@@ -82,11 +82,7 @@ extension Bitboard {
 
 }
 
-extension Bitboard: CustomDebugStringConvertible {
-
-    public var debugDescription: String {
-        chessString()
-    }
+extension Bitboard {
 
     /// Converts the `Bitboard` to an 8x8 board representation string.
     ///

--- a/Sources/ChessKit/Bitboards/Bitboard.swift
+++ b/Sources/ChessKit/Bitboards/Bitboard.swift
@@ -91,6 +91,8 @@ extension Bitboard {
     /// - parameter labelRanks: Whether or not to label ranks (i.e. 1, 2, 3, ...).
     /// - parameter labelFiles: Whether or not to label ranks (i.e. a, b, c, ...).
     /// - returns: A string representing an 8x8 chess board.
+    /// 
+    // periphery:ignore
     func chessString(
         _ occupied: Character = "⨯",
         _ empty: Character = "·",

--- a/Sources/ChessKit/Bitboards/Bitboard.swift
+++ b/Sources/ChessKit/Bitboards/Bitboard.swift
@@ -131,13 +131,3 @@ extension Bitboard {
         return indices.compactMap(Square.init)
     }
 }
-
-extension [Bitboard: Bitboard] {
-    /// Allows non-nil indexing of the dictionary.
-    ///
-    /// If a value is not found for the provided
-    /// key, an empty bitboard is returned.
-    subscript(safe bb: Bitboard) -> Bitboard {
-        self[bb] ?? 0
-    }
-}

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -6,7 +6,6 @@
 /// Delegate protocol that allows the implementer to receive
 /// events related to changes in position on the board such
 /// as pawn promotions and end results.
-///
 public protocol BoardDelegate: AnyObject {
     func didPromote(with move: Move)
     func didEnd(with result: Board.EndResult)
@@ -14,7 +13,6 @@ public protocol BoardDelegate: AnyObject {
 
 /// Manages the state of the chess board and validates
 /// legal moves and game rules.
-///
 public struct Board {
 
     // MARK: - Properties
@@ -49,7 +47,7 @@ public struct Board {
     /// - parameter start: The starting square of the piece.
     /// - parameter end: The ending square of the piece.
     ///
-    /// - returns: The `Move` object representing the move.
+    /// - returns: The ``Move`` object representing the move.
     ///
     /// If `start` doesn't contain a piece or `end` is not a valid legal move
     /// for the piece at `start`, `nil` is returned.
@@ -64,7 +62,6 @@ public struct Board {
     /// - Moving the king in a castling move will also move the
     /// corresponding rook.
     /// - Moving to capture a piece removes the captured piece from the board.
-    ///
     @discardableResult
     public mutating func move(pieceAt start: Square, to end: Square) -> Move? {
         guard canMove(pieceAt: start, to: end), let piece = set.get(start) else {
@@ -186,7 +183,6 @@ public struct Board {
     /// Call this when a pawn reaches the opposite side of the board
     /// and a piece to promote to is selected to complete the promotion
     /// move.
-    ///
     @discardableResult
     public mutating func completePromotion(of move: Move, to kind: Piece.Kind) -> Move {
         let promotedPiece = Piece(kind, color: move.piece.color, square: move.end)
@@ -252,7 +248,6 @@ public struct Board {
     /// For example, if two identical pieces can legally move
     /// to a given square, this method determines whether to
     /// disambiguate them by starting file, rank, or square.
-    ///
     private func disambiguate(move: Move, in set: PieceSet) -> Move {
         let movePiece = move.piece
 
@@ -384,8 +379,7 @@ public struct Board {
     /// - parameter set: The set of pieces active on the board.
     /// - returns: A bitboard of the possible non-capturing pawn moves.
     ///
-    /// For the purposes of `Board`, en-passant is considered a non-capturing move.
-    ///
+    /// For the purposes of ``Board``, en-passant is considered a non-capturing move.
     private func pawnMoves(
         _ color: Piece.Color,
         from sq: Bitboard,
@@ -430,8 +424,7 @@ public struct Board {
     ///
     /// - returns: A bitboard of the possible capturing pawn moves.
     ///
-    /// For the purposes of `Board`, en-passant is not considered a capturing move.
-    ///
+    /// For the purposes of ``Board``, en-passant is not considered a capturing move.
     private func pawnCaptures(
         _ color: Piece.Color,
         from sq: Bitboard

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -298,7 +298,7 @@ public struct Board {
         case .bishop:
             bishopAttacks(from: piece.square, occupancy: set.all)
         case .knight:
-            knightAttacks[safe: piece.square.bb]
+            knightAttacks[piece.square.bb, default: 0]
         case .pawn:
             pawnAttacks(piece.color, from: piece.square.bb, set: set)
         }
@@ -353,10 +353,10 @@ public struct Board {
     ) -> Bitboard {
         guard let square = Square(sq) else { return 0 }
 
-        return kingAttacks[safe: sq] & set.kings
+        return kingAttacks[sq, default: 0] & set.kings
         | rookAttacks(from: square, occupancy: set.all) & set.lines
         | bishopAttacks(from: square, occupancy: set.all) & set.diagonals
-        | knightAttacks[safe: sq] & set.knights
+        | knightAttacks[sq, default: 0] & set.knights
         | pawnCaptures(.white, from: sq) & set.p
         | pawnCaptures(.black, from: sq) & set.P
     }
@@ -507,7 +507,7 @@ public struct Board {
             castleMoves.append(queenSide.kingEnd)
         }
 
-        return kingAttacks[safe: sq] + castleMoves.bb
+        return kingAttacks[sq, default: 0] + castleMoves.bb
     }
 
     /// Determines whether the king of the provided `color` can

--- a/Sources/ChessKit/Configuration.swift
+++ b/Sources/ChessKit/Configuration.swift
@@ -6,19 +6,19 @@
 /// Stores configuration options for the `ChessKit` package.
 public struct ChessKitConfiguration {
 
-    /// Configuration options for printing `Board` and `Position` objects, useful
+    /// Configuration options for printing ``Board`` and ``Position`` objects, useful
     /// for debugging.
     public static var printOptions: PrintOptions = .init()
 
     public struct PrintOptions {
         /// Whether to print pieces as letters (`letter`) or unicode graphics (`graphic`)
-        /// when printing `Board` and `Position` objects.
+        /// when printing ``Board`` and ``Position`` objects.
         ///
         /// The default value is `graphic`.
         public var mode: PrintMode = .graphic
 
         /// Whether to print rank and file labels
-        /// when printing `Board` and `Position` objects.
+        /// when printing ``Board`` and ``Position`` objects.
         ///
         /// The default value is `graphic`.
         public var showCoordinates = true
@@ -35,7 +35,7 @@ public struct ChessKitConfiguration {
     }
 
     /// Whether to print pieces as letters (`letter`) or unicode graphics (`graphic`)
-    /// when printing `Board` and `Position` objects.
+    /// when printing ``Board`` and ``Position`` objects.
     ///
     /// The default value is `graphic`.
     @available(*, deprecated, renamed: "printOptions.mode")

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -10,7 +10,6 @@ import Foundation
 /// This object is the entry point for interacting with a full
 /// chess game within `ChessKit`. It provides methods for
 /// making moves and publishes the played moves in an observable way.
-///
 public class Game: ObservableObject {
 
     // MARK: - Properties
@@ -77,13 +76,12 @@ public class Game: ObservableObject {
     /// it will attempt to make the move defined by `move` by moving
     /// pieces at the provided starting/ending squares and making any
     /// necessary captures, promotions, etc. It is the responsibility
-    /// of the caller to ensure the move is legal, see the `Board` struct.
+    /// of the caller to ensure the move is legal, see the ``Board`` struct.
     ///
     /// If `move` is the same as the upcoming move in the
     /// current variation of `index`, the move is not made, otherwise
     /// another variation with the same first move as the existing one
     /// would be created.
-    ///
     @discardableResult
     public func make(
         move: Move,
@@ -136,8 +134,7 @@ public class Game: ObservableObject {
     /// it will attempt to make the move defined by `moveString` by moving
     /// pieces at the provided starting/ending squares and making any
     /// necessary captures, promotions, etc. It is the responsibility
-    /// of the caller to ensure the move is legal, see the `Board` struct.
-    ///
+    /// of the caller to ensure the move is legal, see the ``Board`` struct.
     @discardableResult
     public func make(
         move moveString: String,
@@ -165,8 +162,7 @@ public class Game: ObservableObject {
     /// it will attempt to make the moves defined by `moveStrings` by moving
     /// pieces at the provided starting/ending squares and making any
     /// necessary captures, promotions, etc. It is the responsibility
-    /// of the caller to ensure the moves are legal, see the `Board` struct.
-    ///
+    /// of the caller to ensure the moves are legal, see the ``Board`` struct.
     @discardableResult
     public func make(
         moves moveStrings: [String],
@@ -183,7 +179,7 @@ public class Game: ObservableObject {
 
     /// Annotates the move at the provided `index`.
     ///
-    /// - parameter index: The index of the move within the `MoveTree`.
+    /// - parameter index: The index of the move within the ``MoveTree``.
     /// - parameter assessment: The move assessment annotation.
     /// - parameter comment: The move comment annotation.
     /// 

--- a/Sources/ChessKit/Move.swift
+++ b/Sources/ChessKit/Move.swift
@@ -120,16 +120,16 @@ extension Move {
         /// The human-readable move assessment notation.
         public var notation: String {
             switch self {
-            case .null:         return ""
-            case .good:         return "!"
-            case .mistake:      return "?"
-            case .brilliant:    return "!!"
-            case .blunder:      return "??"
-            case .interesting:  return "!?"
-            case .dubious:      return "?!"
-            case .forced:       return "□"
-            case .singular:     return ""
-            case .worst:        return ""
+            case .null:        ""
+            case .good:        "!"
+            case .mistake:     "?"
+            case .brilliant:   "!!"
+            case .blunder:     "??"
+            case .interesting: "!?"
+            case .dubious:     "?!"
+            case .forced:      "□"
+            case .singular:    ""
+            case .worst:       ""
             }
         }
     }

--- a/Sources/ChessKit/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree.swift
@@ -23,14 +23,13 @@ public struct MoveTree {
     /// move exists at that index.
     ///
     /// This value can also be accessed using a subscript on
-    /// the `MoveTree` directly,
+    /// the ``MoveTree`` directly,
     /// e.g. `tree[.init(number: 2, color: .white)]`
-    ///
     public func move(at index: Index) -> Move? {
         dictionary[index]?.move
     }
 
-    /// Subscript implementation for `MoveTree`.
+    /// Subscript implementation for ``MoveTree``.
     ///
     /// This method returns the same value as `move(at:)`.
     public subscript(_ index: Index) -> Move? {
@@ -57,6 +56,7 @@ public struct MoveTree {
     /// move is set to the `head` of the move tree.
     ///
     /// - returns: The move index resulting from the addition of the move.
+    ///
     @discardableResult
     public mutating func add(
         move: Move,
@@ -262,7 +262,7 @@ public struct MoveTree {
         return results
     }
 
-    /// The direction of the `MoveTree` path.
+    /// The direction of the ``MoveTree`` path.
     public enum PathDirection {
         /// Move forward (i.e. perform a move).
         case forward
@@ -280,6 +280,7 @@ public struct MoveTree {
     /// - parameter index: The index of the move to annotate.
     /// - parameter assessment: The move to annotate the move with.
     /// - parameter comment: The comment to annotate the move with.
+    ///
     public mutating func annotate(
         moveAt index: MoveTree.Index,
         assessment: Move.Assessment = .null,
@@ -335,7 +336,7 @@ public struct MoveTree {
         return result
     }
 
-    /// Returns the `MoveTree` as an array of PGN
+    /// Returns the ``MoveTree`` as an array of PGN
     /// (Portable Game Format) elements.
     public var pgnRepresentation: [PGNElement] {
         pgn(for: root)
@@ -383,7 +384,7 @@ extension MoveTree {
 
 extension MoveTree {
 
-    /// An element for representing the `MoveTree` in
+    /// An element for representing the ``MoveTree`` in
     /// PGN (Portable Game Notation) format.
     public enum PGNElement: Hashable, Equatable {
         /// e.g. `1.`

--- a/Sources/ChessKit/Parsers/EngineLANParser.swift
+++ b/Sources/ChessKit/Parsers/EngineLANParser.swift
@@ -17,7 +17,6 @@
 ///
 /// See [UCI protocol documentation](https://backscattering.de/chess/uci/2006-04.txt)
 /// for more information.
-///
 public class EngineLANParser {
 
     private init() {}
@@ -32,7 +31,6 @@ public class EngineLANParser {
     ///
     /// This parser does not look for checks or checkmates,
     /// i.e. the move's `checkState` will always be `.none`.
-    ///
     public static func parse(
         move lan: String,
         for color: Piece.Color,
@@ -88,7 +86,7 @@ public class EngineLANParser {
         return move
     }
 
-    /// Converts a `Move` object into an engine LAN string.
+    /// Converts a ``Move`` object into an engine LAN string.
     ///
     /// - parameter move: The chess move to convert.
     /// - returns: A string containing the engine LAN of `move`.

--- a/Sources/ChessKit/Parsers/FENParser.swift
+++ b/Sources/ChessKit/Parsers/FENParser.swift
@@ -10,7 +10,6 @@
 /// ```
 /// "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
 /// ```
-///
 public class FENParser {
 
     private init() {}
@@ -113,7 +112,7 @@ public class FENParser {
         )
     }
 
-    /// Converts a `Position` object into a FEN string.
+    /// Converts a ``Position`` object into a FEN string.
     ///
     /// - parameter position: The chess position to convert.
     /// - returns: A string containing the FEN of `position`.

--- a/Sources/ChessKit/Parsers/PGNParser.swift
+++ b/Sources/ChessKit/Parsers/PGNParser.swift
@@ -231,7 +231,7 @@ public class PGNParser {
         return game
     }
 
-    /// Converts a `Game` object into a PGN string.
+    /// Converts a ``Game`` object into a PGN string.
     ///
     /// - parameter game: The chess game to convert.
     /// - returns: A string containing the PGN of `game`.

--- a/Sources/ChessKit/Parsers/SANParser.swift
+++ b/Sources/ChessKit/Parsers/SANParser.swift
@@ -5,7 +5,6 @@
 
 /// Parses and converts the Standard Algebraic Notation (SAN)
 /// of a chess move.
-///
 public class SANParser {
     
     private init() {}
@@ -19,7 +18,6 @@ public class SANParser {
     ///
     /// Make sure the provided `position` has the correct `sideToMove`
     /// set or the parsing may fail due to invalid moves.
-    ///
     public static func parse(
         move san: String,
         in position: Position
@@ -139,7 +137,7 @@ public class SANParser {
         return nil
     }
     
-    /// Converts a `Move` object into a SAN string.
+    /// Converts a ``Move`` object into a SAN string.
     ///
     /// - parameter move: The chess move to convert.
     /// - returns: A string containing the SAN of `move`.
@@ -240,7 +238,6 @@ public class SANParser {
     /// If multiple pieces of the same type can move to the target
     /// square, the SAN contains a disambiguating file, rank, or square
     /// so the piece that is moving can be determined.
-    ///
     private static func disambiguation(for san: String) -> Move.Disambiguation? {
         guard let range = san.range(of: Regex.disambiguation, options: .regularExpression) else {
             return nil

--- a/Sources/ChessKit/Piece.swift
+++ b/Sources/ChessKit/Piece.swift
@@ -29,12 +29,12 @@ public struct Piece: Equatable, Hashable {
         /// The notation of the given piece kind.
         public var notation: String {
             switch self {
-            case .pawn:             return ""
-            case .bishop:           return "B"
-            case .knight:           return "N"
-            case .rook:             return "R"
-            case .queen:            return "Q"
-            case .king:             return "K"
+            case .pawn:   ""
+            case .bishop: "B"
+            case .knight: "N"
+            case .rook:   "R"
+            case .queen:  "Q"
+            case .king:   "K"
             }
         }
 
@@ -67,32 +67,19 @@ public struct Piece: Equatable, Hashable {
     ///
     init?(fen: String, square: Square) {
         switch fen {
-        case "p":
-            self = Piece(.pawn,   color: .black, square: square)
-        case "b":
-            self = Piece(.bishop, color: .black, square: square)
-        case "n":
-            self = Piece(.knight, color: .black, square: square)
-        case "r":
-            self = Piece(.rook,   color: .black, square: square)
-        case "q":
-            self = Piece(.queen,  color: .black, square: square)
-        case "k":
-            self = Piece(.king,   color: .black, square: square)
-        case "P":
-            self = Piece(.pawn,   color: .white, square: square)
-        case "B":
-            self = Piece(.bishop, color: .white, square: square)
-        case "N":
-            self = Piece(.knight, color: .white, square: square)
-        case "R":
-            self = Piece(.rook,   color: .white, square: square)
-        case "Q":
-            self = Piece(.queen,  color: .white, square: square)
-        case "K":
-            self = Piece(.king,   color: .white, square: square)
-        default:
-            return nil
+        case "p": self = Piece(.pawn,   color: .black, square: square)
+        case "b": self = Piece(.bishop, color: .black, square: square)
+        case "n": self = Piece(.knight, color: .black, square: square)
+        case "r": self = Piece(.rook,   color: .black, square: square)
+        case "q": self = Piece(.queen,  color: .black, square: square)
+        case "k": self = Piece(.king,   color: .black, square: square)
+        case "P": self = Piece(.pawn,   color: .white, square: square)
+        case "B": self = Piece(.bishop, color: .white, square: square)
+        case "N": self = Piece(.knight, color: .white, square: square)
+        case "R": self = Piece(.rook,   color: .white, square: square)
+        case "Q": self = Piece(.queen,  color: .white, square: square)
+        case "K": self = Piece(.king,   color: .white, square: square)
+        default:  return nil
         }
     }
 

--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -59,13 +59,11 @@ public struct Position: Equatable {
     }
 
     /// Toggle the current side to move.
-    ///
     private mutating func _toggleSideToMove() {
         sideToMove.toggle()
     }
 
     /// Toggle the current side to move.
-    ///
     @available(*, deprecated, message: "This function no longer has any effect. `sideToMove` is toggled automatically as needed.")
     public mutating func toggleSideToMove() {
 
@@ -152,7 +150,6 @@ public struct Position: Equatable {
     /// - parameter piece: The piece to remove from the position.
     ///
     /// If the piece is not currently located in the position, this method has no effect.
-    ///
     mutating func remove(_ piece: Piece) {
         pieceSet.remove(piece)
     }
@@ -165,7 +162,6 @@ public struct Position: Equatable {
     /// If a piece is not found at the given square, this method has no effect.
     /// This method contains no logic to determine if the piece can be legally
     /// promoted, and such checks should be done before calling this method.
-    ///
     mutating func promote(pieceAt square: Square, to kind: Piece.Kind) {
         guard let piece = pieceSet.get(square) else { return }
         pieceSet.replace(kind, for: piece)

--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -194,8 +194,7 @@ public struct Position: Equatable {
                 let allBLight = set.bishops & .dark == 0 // all bishops on light squares
                 let allBDark = set.bishops & .light == 0 // all bishops on dark squares
 
-                return set.knights == 0
-                && (allBLight || allBDark)
+                return set.knights == 0 && (allBLight || allBDark)
             }
         } else {
             // not insufficient material if pawns, rooks, or queens

--- a/Sources/ChessKit/Special Moves/Castling.swift
+++ b/Sources/ChessKit/Special Moves/Castling.swift
@@ -11,7 +11,7 @@ struct LegalCastlings: Equatable {
     /// Initialize a `LegalCastlings` struct with an
     /// array of legal castling moves.
     ///
-    /// - parameter legal: An array of legal `Castling` moves.
+    /// - parameter legal: An array of legal ``Castling`` moves.
     ///
     init(legal: [Castling] = [.bK, .wK, .bQ, .wQ]) {
         self.legal = legal
@@ -25,7 +25,6 @@ struct LegalCastlings: Equatable {
     ///
     /// For example, if a king has moved, pass the king piece to this
     /// method to remove any castlings associated with that king.
-    ///
     mutating func invalidateCastling(for piece: Piece) {
         if piece.kind == .king {
             legal.removeAll { $0.color == piece.color }

--- a/Sources/ChessKit/Special Moves/EnPassant.swift
+++ b/Sources/ChessKit/Special Moves/EnPassant.swift
@@ -23,7 +23,6 @@ struct EnPassant: Equatable, Hashable {
     /// same rank as the target pawn and exactly 1 file away from the
     /// target pawn for this method to return `true`, otherwise `false`
     /// is returned.
-    ///
     func canBeCaptured(by capturingPiece: Piece) -> Bool {
         capturingPiece.kind == .pawn &&
         capturingPiece.color == pawn.color.opposite &&

--- a/Sources/ChessKit/Square.swift
+++ b/Sources/ChessKit/Square.swift
@@ -15,7 +15,6 @@ public enum Square: Int, Equatable, CaseIterable {
         /// Square.File.a.number // 1
         /// Square.File.h.number // 8
         /// ```
-        ///
         public var number: Int {
             File.allCases.firstIndex(of: self)! + 1
         }
@@ -28,7 +27,6 @@ public enum Square: Int, Equatable, CaseIterable {
         /// greater than 8, the file is set to `.a`.
         ///
         /// See also `Square.File.number`.
-        ///
         public init(_ number: Int) {
             switch number {
             case 1:   self = .a
@@ -93,71 +91,71 @@ public enum Square: Int, Equatable, CaseIterable {
     ///
     init(_ file: File, _ rank: Rank) {
         switch (file, rank) {
-        case (.a, 1):   self = .a1
-        case (.a, 2):   self = .a2
-        case (.a, 3):   self = .a3
-        case (.a, 4):   self = .a4
-        case (.a, 5):   self = .a5
-        case (.a, 6):   self = .a6
-        case (.a, 7):   self = .a7
-        case (.a, 8):   self = .a8
-        case (.b, 1):   self = .b1
-        case (.b, 2):   self = .b2
-        case (.b, 3):   self = .b3
-        case (.b, 4):   self = .b4
-        case (.b, 5):   self = .b5
-        case (.b, 6):   self = .b6
-        case (.b, 7):   self = .b7
-        case (.b, 8):   self = .b8
-        case (.c, 1):   self = .c1
-        case (.c, 2):   self = .c2
-        case (.c, 3):   self = .c3
-        case (.c, 4):   self = .c4
-        case (.c, 5):   self = .c5
-        case (.c, 6):   self = .c6
-        case (.c, 7):   self = .c7
-        case (.c, 8):   self = .c8
-        case (.d, 1):   self = .d1
-        case (.d, 2):   self = .d2
-        case (.d, 3):   self = .d3
-        case (.d, 4):   self = .d4
-        case (.d, 5):   self = .d5
-        case (.d, 6):   self = .d6
-        case (.d, 7):   self = .d7
-        case (.d, 8):   self = .d8
-        case (.e, 1):   self = .e1
-        case (.e, 2):   self = .e2
-        case (.e, 3):   self = .e3
-        case (.e, 4):   self = .e4
-        case (.e, 5):   self = .e5
-        case (.e, 6):   self = .e6
-        case (.e, 7):   self = .e7
-        case (.e, 8):   self = .e8
-        case (.f, 1):   self = .f1
-        case (.f, 2):   self = .f2
-        case (.f, 3):   self = .f3
-        case (.f, 4):   self = .f4
-        case (.f, 5):   self = .f5
-        case (.f, 6):   self = .f6
-        case (.f, 7):   self = .f7
-        case (.f, 8):   self = .f8
-        case (.g, 1):   self = .g1
-        case (.g, 2):   self = .g2
-        case (.g, 3):   self = .g3
-        case (.g, 4):   self = .g4
-        case (.g, 5):   self = .g5
-        case (.g, 6):   self = .g6
-        case (.g, 7):   self = .g7
-        case (.g, 8):   self = .g8
-        case (.h, 1):   self = .h1
-        case (.h, 2):   self = .h2
-        case (.h, 3):   self = .h3
-        case (.h, 4):   self = .h4
-        case (.h, 5):   self = .h5
-        case (.h, 6):   self = .h6
-        case (.h, 7):   self = .h7
-        case (.h, 8):   self = .h8
-        default:        self = .a1
+        case (.a, 1): self = .a1
+        case (.a, 2): self = .a2
+        case (.a, 3): self = .a3
+        case (.a, 4): self = .a4
+        case (.a, 5): self = .a5
+        case (.a, 6): self = .a6
+        case (.a, 7): self = .a7
+        case (.a, 8): self = .a8
+        case (.b, 1): self = .b1
+        case (.b, 2): self = .b2
+        case (.b, 3): self = .b3
+        case (.b, 4): self = .b4
+        case (.b, 5): self = .b5
+        case (.b, 6): self = .b6
+        case (.b, 7): self = .b7
+        case (.b, 8): self = .b8
+        case (.c, 1): self = .c1
+        case (.c, 2): self = .c2
+        case (.c, 3): self = .c3
+        case (.c, 4): self = .c4
+        case (.c, 5): self = .c5
+        case (.c, 6): self = .c6
+        case (.c, 7): self = .c7
+        case (.c, 8): self = .c8
+        case (.d, 1): self = .d1
+        case (.d, 2): self = .d2
+        case (.d, 3): self = .d3
+        case (.d, 4): self = .d4
+        case (.d, 5): self = .d5
+        case (.d, 6): self = .d6
+        case (.d, 7): self = .d7
+        case (.d, 8): self = .d8
+        case (.e, 1): self = .e1
+        case (.e, 2): self = .e2
+        case (.e, 3): self = .e3
+        case (.e, 4): self = .e4
+        case (.e, 5): self = .e5
+        case (.e, 6): self = .e6
+        case (.e, 7): self = .e7
+        case (.e, 8): self = .e8
+        case (.f, 1): self = .f1
+        case (.f, 2): self = .f2
+        case (.f, 3): self = .f3
+        case (.f, 4): self = .f4
+        case (.f, 5): self = .f5
+        case (.f, 6): self = .f6
+        case (.f, 7): self = .f7
+        case (.f, 8): self = .f8
+        case (.g, 1): self = .g1
+        case (.g, 2): self = .g2
+        case (.g, 3): self = .g3
+        case (.g, 4): self = .g4
+        case (.g, 5): self = .g5
+        case (.g, 6): self = .g6
+        case (.g, 7): self = .g7
+        case (.g, 8): self = .g8
+        case (.h, 1): self = .h1
+        case (.h, 2): self = .h2
+        case (.h, 3): self = .h3
+        case (.h, 4): self = .h4
+        case (.h, 5): self = .h5
+        case (.h, 6): self = .h6
+        case (.h, 7): self = .h7
+        case (.h, 8): self = .h8
+        default:      self = .a1
         }
     }
 

--- a/Sources/ChessKit/Square.swift
+++ b/Sources/ChessKit/Square.swift
@@ -166,28 +166,28 @@ public enum Square: Int, Equatable, CaseIterable {
     /// The file (column) of the given square, from `a` through `h`.
     public var file: File {
         switch self {
-        case .a1, .a2, .a3, .a4, .a5, .a6, .a7, .a8: return .a
-        case .b1, .b2, .b3, .b4, .b5, .b6, .b7, .b8: return .b
-        case .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8: return .c
-        case .d1, .d2, .d3, .d4, .d5, .d6, .d7, .d8: return .d
-        case .e1, .e2, .e3, .e4, .e5, .e6, .e7, .e8: return .e
-        case .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8: return .f
-        case .g1, .g2, .g3, .g4, .g5, .g6, .g7, .g8: return .g
-        case .h1, .h2, .h3, .h4, .h5, .h6, .h7, .h8: return .h
+        case .a1, .a2, .a3, .a4, .a5, .a6, .a7, .a8: .a
+        case .b1, .b2, .b3, .b4, .b5, .b6, .b7, .b8: .b
+        case .c1, .c2, .c3, .c4, .c5, .c6, .c7, .c8: .c
+        case .d1, .d2, .d3, .d4, .d5, .d6, .d7, .d8: .d
+        case .e1, .e2, .e3, .e4, .e5, .e6, .e7, .e8: .e
+        case .f1, .f2, .f3, .f4, .f5, .f6, .f7, .f8: .f
+        case .g1, .g2, .g3, .g4, .g5, .g6, .g7, .g8: .g
+        case .h1, .h2, .h3, .h4, .h5, .h6, .h7, .h8: .h
         }
     }
 
     /// The rank (row) of the given square, from `1` to `8`.
     public var rank: Rank {
         switch self {
-        case .a1, .b1, .c1, .d1, .e1, .f1, .g1, .h1: return 1
-        case .a2, .b2, .c2, .d2, .e2, .f2, .g2, .h2: return 2
-        case .a3, .b3, .c3, .d3, .e3, .f3, .g3, .h3: return 3
-        case .a4, .b4, .c4, .d4, .e4, .f4, .g4, .h4: return 4
-        case .a5, .b5, .c5, .d5, .e5, .f5, .g5, .h5: return 5
-        case .a6, .b6, .c6, .d6, .e6, .f6, .g6, .h6: return 6
-        case .a7, .b7, .c7, .d7, .e7, .f7, .g7, .h7: return 7
-        case .a8, .b8, .c8, .d8, .e8, .f8, .g8, .h8: return 8
+        case .a1, .b1, .c1, .d1, .e1, .f1, .g1, .h1: 1
+        case .a2, .b2, .c2, .d2, .e2, .f2, .g2, .h2: 2
+        case .a3, .b3, .c3, .d3, .e3, .f3, .g3, .h3: 3
+        case .a4, .b4, .c4, .d4, .e4, .f4, .g4, .h4: 4
+        case .a5, .b5, .c5, .d5, .e5, .f5, .g5, .h5: 5
+        case .a6, .b6, .c6, .d6, .e6, .f6, .g6, .h6: 6
+        case .a7, .b7, .c7, .d7, .e7, .f7, .g7, .h7: 7
+        case .a8, .b8, .c8, .d8, .e8, .f8, .g8, .h8: 8
         }
     }
     
@@ -206,9 +206,9 @@ public enum Square: Int, Equatable, CaseIterable {
     /// The color of the square on the board, either light or dark.
     public var color: Color {
         if (file.number % 2 == 0 && rank.value % 2 == 0) || (file.number % 2 != 0 && rank.value % 2 != 0) {
-            return .dark
+            .dark
         } else {
-            return .light
+            .light
         }
     }
 }


### PR DESCRIPTION
* Removed `CustomDebugStringConvertible` conformance on `Bitboard` as this was causing every `UInt64` to debug print as a chess board (funny but not ideal).
  * `Bitboard.chessString()` can be used to obtain the same string.
* Improved documentation comment formatting.
* Removed unnecessary "safe" dictionary subscript for `Bitboard` dictionaries (replaced with `default:`)
* Removed redundant `return` keyword where possible.