### PR TITLE
Enable strict concurrency in Swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [unreleased]
+
+* Update tools version to Swift 5.9
+* Conform to strict concurrency in Swift and add Sendable conformance to most objects
+
 # ChessKit 0.9.0
 Released Saturday, June 15, 2024.
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.7
+// swift-tools-version: 5.9
 
 import PackageDescription
 
@@ -20,7 +20,10 @@ let package = Package(
     targets: [
         .target(
             name: "ChessKit",
-            dependencies: []
+            dependencies: [],
+            swiftSettings: [
+                .enableExperimentalFeature("StrictConcurrency")
+            ]
         ),
         .testTarget(
             name: "ChessKitTests",

--- a/Sources/ChessKit/Bitboards/Attacks.swift
+++ b/Sources/ChessKit/Bitboards/Attacks.swift
@@ -5,20 +5,20 @@
 
 /// Stores pre-generated pseudo-legal attack bitboards
 /// for non-pawn piece types.
-struct Attacks {
+struct Attacks: Sendable {
 
     /// Cached king attacks, the dictionary key
     /// corresponds to `Square.bb`.
-    static var kings = [Bitboard: Bitboard]()
+    private(set) nonisolated(unsafe) static var kings = [Bitboard: Bitboard]()
     /// Cached rook attacks, the array index corresponds
     /// to `Square.rawValue`.
-    static var rooks = [Magic]()
+    private(set) nonisolated(unsafe) static var rooks = [Magic]()
     /// Cached bishop attacks, the array index corresponds
     /// to `Square.rawValue`.
-    static var bishops = [Magic]()
+    private(set) nonisolated(unsafe) static var bishops = [Magic]()
     /// Cached king attacks, the dictionary key
     /// corresponds to `Square.bb`.
-    static var knights = [Bitboard: Bitboard]()
+    private(set) nonisolated(unsafe) static var knights = [Bitboard: Bitboard]()
 
     /// Generates and caches attack bitboards for all piece kinds.
     static func create() {
@@ -235,7 +235,7 @@ struct Attacks {
     /// Magic numbers for calculating bishop and rook magic bitboards.
     ///
     /// Derived by [Pradyumna Kannan](http://pradu.us/old/Nov27_2008/Buzz/research/magic/Bitboards.pdf).
-    private static var magicNumbers: [Piece.Kind: [Bitboard]] = [
+    private static let magicNumbers: [Piece.Kind: [Bitboard]] = [
         .bishop: [
             0x0002020202020200, 0x0002020202020000, 0x0004010202000000, 0x0004040080000000,
             0x0001104000000000, 0x0000821040000000, 0x0000410410400000, 0x0000104104104000,
@@ -278,7 +278,7 @@ struct Attacks {
 
 /// Stores the magic factors and attacks for a given piece
 /// type (bishop or rook) and square (a1-h8).
-struct Magic {
+struct Magic: Sendable {
     /// The magic number used to compute the hash key.
     fileprivate var magic: Bitboard
     /// The bitmask representing the possible moves on an empty board

--- a/Sources/ChessKit/Bitboards/PieceSet.swift
+++ b/Sources/ChessKit/Bitboards/PieceSet.swift
@@ -7,7 +7,7 @@
 ///
 /// Also contains convenient amalgamations
 /// of different combinations of pieces.
-struct PieceSet: Equatable {
+struct PieceSet: Equatable, Sendable {
     /// Bitboard for black king pieces.
     var k: Bitboard = 0
     /// Bitboard for black queen pieces.

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -6,14 +6,14 @@
 /// Delegate protocol that allows the implementer to receive
 /// events related to changes in position on the board such
 /// as pawn promotions and end results.
-public protocol BoardDelegate: AnyObject {
+public protocol BoardDelegate: AnyObject, Sendable {
     func didPromote(with move: Move)
     func didEnd(with result: Board.EndResult)
 }
 
 /// Manages the state of the chess board and validates
 /// legal moves and game rules.
-public struct Board {
+public struct Board: Sendable {
 
     // MARK: - Properties
 
@@ -535,14 +535,14 @@ public struct Board {
 
 extension Board {
     /// Represents an end result of a standard chess game.
-    public enum EndResult: Equatable {
+    public enum EndResult: Equatable, Sendable {
         /// The board represents a win for the given color.
         case win(Piece.Color)
         /// The board represents a draw with a given reason.
         case draw(DrawType)
 
         /// The type of draw represented on the board.
-        public enum DrawType: String {
+        public enum DrawType: String, Sendable {
             case agreement
             case fiftyMoves
             case insufficientMaterial

--- a/Sources/ChessKit/Clock.swift
+++ b/Sources/ChessKit/Clock.swift
@@ -5,11 +5,11 @@
 
 /// Tracks the number of moves in a game for
 /// the purposes of regulating the 50 move rule.
-public struct Clock: Equatable {
+public struct Clock: Equatable, Sendable {
 
     /// The maximum number of half moves before
     /// a draw by the fifty move rule should be called.
-    static var halfMoveMaximum = 100
+    static let halfMoveMaximum = 100
 
     /// The number of halfmoves, incremented after each move.
     /// It is reset to zero after each capture or pawn move.

--- a/Sources/ChessKit/Configuration.swift
+++ b/Sources/ChessKit/Configuration.swift
@@ -4,18 +4,18 @@
 //
 
 /// Stores configuration options for the `ChessKit` package.
-public struct ChessKitConfiguration {
+public struct ChessKitConfiguration: Sendable {
 
     /// Configuration options for printing ``Board`` and ``Position`` objects, useful
     /// for debugging.
-    public static var printOptions: PrintOptions = .init()
+    public nonisolated(unsafe) static var printOptions = PrintOptions()
 
-    public struct PrintOptions {
+    public struct PrintOptions: Sendable {
         /// Whether to print pieces as letters (`letter`) or unicode graphics (`graphic`)
         /// when printing ``Board`` and ``Position`` objects.
         ///
         /// The default value is `graphic`.
-        public var mode: PrintMode = .graphic
+        public var mode = PrintMode.graphic
 
         /// Whether to print rank and file labels
         /// when printing ``Board`` and ``Position`` objects.
@@ -24,7 +24,7 @@ public struct ChessKitConfiguration {
         public var showCoordinates = true
 
         /// ChessKit `printMode` options.
-        public enum PrintMode {
+        public enum PrintMode: Sendable {
             /// Print pieces as unicode graphic characters, e.g. ♟, ♞, ♝, ♜, ♛, ♚.
             case graphic
             /// Print pieces as FEN letters, e.g. P, N, B, R, Q, K.

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -214,7 +214,7 @@ extension Game {
 
     /// Denotes a PGN tag pair.
     @propertyWrapper
-    public struct Tag {
+    public struct Tag: Sendable {
 
         /// The name of the tag pair.
         ///

--- a/Sources/ChessKit/Move.swift
+++ b/Sources/ChessKit/Move.swift
@@ -3,17 +3,17 @@
 //  ChessKit
 //
 
-public struct Move: Equatable, Hashable {
+public struct Move: Equatable, Hashable, Sendable {
 
     /// The result of the move.
-    public enum Result: Equatable, Hashable {
+    public enum Result: Equatable, Hashable, Sendable {
         case move
         case capture(Piece)
         case castle(Castling)
     }
 
     /// The check state resulting from the move.
-    public enum CheckState: String {
+    public enum CheckState: String, Sendable {
         case none
         case check
         case checkmate
@@ -29,7 +29,7 @@ public struct Move: Equatable, Hashable {
     }
 
     /// Rank, file, or square disambiguation of moves.
-    public enum Disambiguation: Equatable, Hashable {
+    public enum Disambiguation: Equatable, Hashable, Sendable {
         case byFile(Square.File)
         case byRank(Square.Rank)
         case bySquare(Square)
@@ -105,7 +105,7 @@ extension Move {
     ///
     /// The raw String value corresponds to what is displayed
     /// in a PGN string.
-    public enum Assessment: String {
+    public enum Assessment: String, Sendable {
         case null = "$0"
         case good = "$1"
         case mistake = "$2"

--- a/Sources/ChessKit/MoveTree/MoveTree+Index.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree+Index.swift
@@ -5,7 +5,7 @@
 
 extension MoveTree {
     /// Object that represents the index of a node in the move tree.
-    public struct Index: Hashable {
+    public struct Index: Hashable, Sendable {
 
         public static let mainVariation = 0
 

--- a/Sources/ChessKit/MoveTree/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree.swift
@@ -228,7 +228,7 @@ public struct MoveTree {
     }
 
     /// The direction of the ``MoveTree`` path.
-    public enum PathDirection {
+    public enum PathDirection: Sendable {
         /// Move forward (i.e. perform a move).
         case forward
         /// Move backward (i.e. undo a move).
@@ -263,7 +263,7 @@ public struct MoveTree {
 
     /// An element for representing the ``MoveTree`` in
     /// PGN (Portable Game Notation) format.
-    public enum PGNElement: Hashable, Equatable {
+    public enum PGNElement: Hashable, Equatable, Sendable {
         /// e.g. `1.`
         case whiteNumber(Int)
         /// e.g. `1...`

--- a/Sources/ChessKit/Piece.swift
+++ b/Sources/ChessKit/Piece.swift
@@ -4,10 +4,10 @@
 //
 
 /// Represents a piece on the chess board.
-public struct Piece: Equatable, Hashable {
+public struct Piece: Equatable, Hashable, Sendable {
 
     /// Represents the color of a piece.
-    public enum Color: String, CaseIterable {
+    public enum Color: String, CaseIterable, Sendable {
         case black = "b", white = "w"
 
         /// The opposite color of the given color.
@@ -22,7 +22,7 @@ public struct Piece: Equatable, Hashable {
     }
 
     /// Represents the type of piece.
-    public enum Kind: String, CaseIterable {
+    public enum Kind: String, CaseIterable, Sendable {
         case pawn = ""
         case knight = "N", bishop = "B", rook = "R", queen = "Q", king = "K"
 

--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -4,7 +4,7 @@
 //
 
 /// Represents the collection of pieces on the chess board.
-public struct Position: Equatable {
+public struct Position: Equatable, Sendable {
 
     /// The pieces currently existing on the board in this position.
     public var pieces: [Piece] {

--- a/Sources/ChessKit/Special Moves/Castling.swift
+++ b/Sources/ChessKit/Special Moves/Castling.swift
@@ -4,7 +4,7 @@
 //
 
 /// Structure that captures legal castling moves.
-struct LegalCastlings: Equatable {
+struct LegalCastlings: Equatable, Sendable {
 
     private var legal: [Castling]
 
@@ -55,7 +55,7 @@ struct LegalCastlings: Equatable {
 ///
 /// Contains various characteristics of the castling move
 /// such as king and rook start and end squares and notation.
-public struct Castling: Equatable, Hashable {
+public struct Castling: Equatable, Hashable, Sendable {
 
     /// Kingside castle for black.
     static let bK = Castling(side: .king, color: .black)
@@ -68,7 +68,7 @@ public struct Castling: Equatable, Hashable {
 
     /// Represents the side of the board from which castling an occur.
     /// Either `king` or `queen`.
-    enum Side: CaseIterable {
+    enum Side: CaseIterable, Sendable {
         case king, queen
 
         var notation: String {

--- a/Sources/ChessKit/Special Moves/EnPassant.swift
+++ b/Sources/ChessKit/Special Moves/EnPassant.swift
@@ -4,7 +4,7 @@
 //
 
 /// Structure that captures en passant moves.
-struct EnPassant: Equatable, Hashable {
+struct EnPassant: Equatable, Hashable, Sendable {
 
     /// Pawn that is capable of being captured by en passant.
     var pawn: Piece

--- a/Sources/ChessKit/Square.swift
+++ b/Sources/ChessKit/Square.swift
@@ -3,9 +3,9 @@
 //  ChessKit
 //
 
-public enum Square: Int, Equatable, CaseIterable {
+public enum Square: Int, Equatable, CaseIterable, Sendable {
     /// The file on the chess board, from a to h.
-    public enum File: String, CaseIterable  {
+    public enum File: String, CaseIterable, Sendable {
         case a, b, c, d, e, f, g, h
 
         /// The number corresponding to the file.
@@ -43,7 +43,7 @@ public enum Square: Int, Equatable, CaseIterable {
     }
 
     /// The rank on the chess board, from 1 to 8.
-    public struct Rank: ExpressibleByIntegerLiteral, Equatable, Hashable {
+    public struct Rank: ExpressibleByIntegerLiteral, Equatable, Hashable, Sendable {
         /// The possible range of Rank numbers.
         public static let range = 1...8
 


### PR DESCRIPTION
* Update to `swift-tools-version: 5.9`
* Resolve strict concurrency warnings
* Add `Sendable` conformance to most objects where possible