### PR TITLE
Notify when kings are checked on board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# [unreleased]
+
+* `BoardDelegate` now notifies when king is in check, and provides the color of the checked king, see [Issue #38](https://github.com/chesskit-app/chesskit-swift/issues/38).
+* `Move.checkState` and `Move.disambiguation` are now publicly accessible, see [Issue #38](https://github.com/chesskit-app/chesskit-swift/issues/38).
+
 # ChessKit 0.12.1
 Released Wednesday, September 11, 2024.
 

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -8,6 +8,7 @@
 /// as pawn promotions and end results.
 public protocol BoardDelegate: AnyObject, Sendable {
   func didPromote(with move: Move)
+  func didCheckKing(ofColor: Piece.Color)
   func didEnd(with result: Board.EndResult)
 }
 
@@ -231,6 +232,8 @@ public struct Board: Sendable {
       delegate?.didEnd(with: .draw(.insufficientMaterial))
     } else if positionHashCounts[position.hashValue] == 3 {
       delegate?.didEnd(with: .draw(.repetition))
+    } else if checkState == .check {
+      delegate?.didCheckKing(ofColor: processedMove.piece.color)
     }
 
     // pawn promotion

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -8,7 +8,7 @@
 /// as pawn promotions and end results.
 public protocol BoardDelegate: AnyObject, Sendable {
   func didPromote(with move: Move)
-  func didCheckKing(ofColor: Piece.Color)
+  func didCheckKing(ofColor color: Piece.Color)
   func didEnd(with result: Board.EndResult)
 }
 
@@ -233,7 +233,7 @@ public struct Board: Sendable {
     } else if positionHashCounts[position.hashValue] == 3 {
       delegate?.didEnd(with: .draw(.repetition))
     } else if checkState == .check {
-      delegate?.didCheckKing(ofColor: processedMove.piece.color)
+      delegate?.didCheckKing(ofColor: processedMove.piece.color.opposite)
     }
 
     // pawn promotion

--- a/Sources/ChessKit/Move.swift
+++ b/Sources/ChessKit/Move.swift
@@ -46,9 +46,9 @@ public struct Move: Hashable, Sendable {
   /// The piece that was promoted to, if applicable.
   public internal(set) var promotedPiece: Piece?
   /// The move disambiguation, if applicable.
-  var disambiguation: Disambiguation?
+  public internal(set) var disambiguation: Disambiguation?
   /// The check state resulting from the move.
-  var checkState: CheckState
+  public internal(set) var checkState: CheckState
   /// The move assessment annotation.
   public var assessment: Assessment
   /// The comment associated with a move.

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -352,8 +352,23 @@ final class BoardTests: XCTestCase {
 
   func testCheckMove() {
     var board = Board(position: .init(fen: "k7/7R/8/8/8/8/K7/8 w - - 0 1")!)
+
+    nonisolated(unsafe) var expectation: XCTestExpectation? = self.expectation(description: "Board returns check result")
+
+    let delegate = MockBoardDelegate(didCheckKing: { color in
+      if color == .black {
+        expectation?.fulfill()
+        expectation = nil
+      } else {
+        XCTFail()
+      }
+    })
+
+    board.delegate = delegate
     let move = board.move(pieceAt: .h7, to: .h8)
     XCTAssertEqual(move?.checkState, .check)
+
+    waitForExpectations(timeout: 1.0)
   }
 
   func testCheckmateMove() {

--- a/Tests/ChessKitTests/Utilities/MockBoardDelegate.swift
+++ b/Tests/ChessKitTests/Utilities/MockBoardDelegate.swift
@@ -21,6 +21,10 @@ final class MockBoardDelegate: BoardDelegate {
     didPromote?(move)
   }
 
+  func didCheckKing(ofColor: Piece.Color) {
+
+  }
+
   func didEnd(with result: Board.EndResult) {
     didEnd?(result)
   }

--- a/Tests/ChessKitTests/Utilities/MockBoardDelegate.swift
+++ b/Tests/ChessKitTests/Utilities/MockBoardDelegate.swift
@@ -7,13 +7,16 @@
 
 final class MockBoardDelegate: BoardDelegate {
   private let didPromote: (@Sendable (Move) -> Void)?
+  private let didCheckKing: (@Sendable (Piece.Color) -> Void)?
   private let didEnd: (@Sendable (Board.EndResult) -> Void)?
 
   init(
     didPromote: (@Sendable (Move) -> Void)? = nil,
+    didCheckKing: (@Sendable (Piece.Color) -> Void)? = nil,
     didEnd: (@Sendable (Board.EndResult) -> Void)? = nil
   ) {
     self.didPromote = didPromote
+    self.didCheckKing = didCheckKing
     self.didEnd = didEnd
   }
 
@@ -21,8 +24,8 @@ final class MockBoardDelegate: BoardDelegate {
     didPromote?(move)
   }
 
-  func didCheckKing(ofColor: Piece.Color) {
-
+  func didCheckKing(ofColor color: Piece.Color) {
+    didCheckKing?(color)
   }
 
   func didEnd(with result: Board.EndResult) {


### PR DESCRIPTION
* Added `didCheckKing(ofColor:)` method to `BoardDelegate` to notify when a king is placed in check.
* Made `Move.checkState` and `Move.disambiguation` publicly readable

resolves #38 