### PR TITLE
FEN parser fix

### DIFF
--- a/Sources/ChessKit/Parsers/FENParser.swift
+++ b/Sources/ChessKit/Parsers/FENParser.swift
@@ -50,6 +50,9 @@ public class FENParser {
             .components(separatedBy: "/")
             .enumerated()
 
+        var kSquare: Square = .e8
+        var KSquare: Square = .e1
+
         let pieces = piecePlacementByRank.compactMap { (index, rankString) -> [Piece]? in
             let piecesInRank = rankString.map(String.init)
             let rank = Square.Rank(Square.Rank.range.upperBound - index)
@@ -65,10 +68,22 @@ public class FENParser {
                     fileNumber += 1
                     let file = Square.File(fileNumber)
                     let square = Square(file, rank)
+
+                    switch s {
+                    case "k": kSquare = square
+                    case "K": KSquare = square
+                    default: break
+                    }
+
                     return Piece(fen: s, square: square)
                 }
             }
         }.flatMap { $0 }
+
+        guard abs(kSquare.rank.value - KSquare.rank.value) > 1 ||
+              abs(kSquare.file.number - KSquare.file.number) > 1 else {
+            return nil
+        }
 
         // side to move
 

--- a/Sources/ChessKit/Parsers/FENParser.swift
+++ b/Sources/ChessKit/Parsers/FENParser.swift
@@ -36,6 +36,14 @@ public class FENParser {
             return nil
         }
 
+        guard separatedFen[0].filter({ $0 == "K" }).count == 1 else {
+            return nil
+        }
+
+        guard separatedFen[0].filter({ $0 == "k" }).count == 1 else {
+            return nil
+        }
+
         // piece placement
 
         let piecePlacementByRank = separatedFen[0]

--- a/Tests/ChessKitTests/Parsers/FENParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/FENParserTests.swift
@@ -93,4 +93,20 @@ class FENParserTests: XCTestCase {
         XCTAssertEqual(Position.fiftyMove.fen, fiftyMoveFen)
     }
 
+    func testKingsCount() {
+        let standardFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        XCTAssertNotNil(Position(fen: standardFen))
+
+        let oneKingFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQQBNR w KQkq - 0 1"
+        let threeKingsFen = "rnbqkbnr/kppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+        XCTAssertNil(Position(fen: oneKingFen))
+        XCTAssertNil(Position(fen: threeKingsFen))
+    }
+    
+    func testAdjacentKings() {
+        let adjacentKings1 = "rnbqbnr1/pppppppp/8/8/8/8/PPPkPPPP/RNBQKBNR w KQkq - 0 1"
+        let adjacentKings2 = "rnbqkKnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQBNR1 w KQkq - 0 1"
+        XCTAssertNil(Position(fen: adjacentKings1))
+        XCTAssertNil(Position(fen: adjacentKings2))
+    }
 }


### PR DESCRIPTION
Hello again! Analysing and using a bit more the package I noticed that there were some problems with the FEN parser, in fact the position was considered valid even if:

1-  There where more/less than 2 kings
2-  The kings were close to each other (which cannot happen in any case)

Probably the 2nd point has to be improved, but tell me what you think 😄 
