### PR TITLE
Bug fix - Pawn promotion is represented incorrectly on game object moves list

### DIFF
--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -178,6 +178,43 @@ public struct Game: Hashable, Sendable {
 
     return index
   }
+    
+
+  /// Promotes the piece the a given move to the selected piece.
+  ///
+  /// - parameter move: The move that promotes the piece.
+  /// - parameter kind: The kind of piece we would like to promote to.
+  /// - parameter index: The current move index to make the moves from.
+  /// If this parameter is `nil` or omitted, the move is made from the
+  /// last move in the main variation branch.
+  /// - returns: The updated move or nil if the update was unsuccessful
+  ///
+  /// This method does not make any move legality assumptions,
+  /// it will attempt to make the moves defined by `moveStrings` by moving
+  /// pieces at the provided starting/ending squares and making any
+  /// necessary captures, promotions, etc. It is the responsibility
+  /// of the caller to ensure the moves are legal, see the ``Board`` struct.
+  @discardableResult
+  public mutating func completePromotion(
+    of move: Move,
+    to kind: Piece.Kind,
+    at index: MoveTree.Index? = nil
+  ) -> Move? {
+    let index = index ?? moves.endIndex
+    let promotedPiece = Piece(kind, color: move.piece.color, square: move.end)
+    
+    guard var position = positions[index] else {
+            return nil
+    }
+        
+    var updatedMove = move
+    updatedMove.promotedPiece = promotedPiece
+
+    position.promote(pieceAt: move.end, to: kind)
+        
+    positions[moves.endIndex] = position
+    return moves.promotePiece(promotedPiece, at: index)
+  }
 
   /// Annotates the move at the provided `index`.
   ///

--- a/Sources/ChessKit/MoveTree/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree.swift
@@ -272,6 +272,22 @@ public struct MoveTree: Hashable, Sendable {
     return dictionary[index]?.move
   }
 
+  /// Appends a promoted piece to a move at a given index.
+  ///
+  /// - parameter promotedPiece: the piece to append to the move.
+  /// - parameter index: The index of the move to promote.
+  ///
+  /// - returns: The move updated with the given promoted piece.
+  ///
+  mutating func promotePiece(
+    _ promotedPiece: Piece,
+    at index: Index
+  ) -> Move? {
+    Self.nodeLock.withLock {
+      dictionary[index]?.move.promotedPiece = promotedPiece
+    }
+    return dictionary[index]?.move.promotedPiece != nil ? dictionary[index]?.move : nil
+  }
   // MARK: - PGN
 
   /// An element for representing the ``MoveTree`` in


### PR DESCRIPTION
This PR addresses an issue where pawn promotion doesn't reflect in the original move object inside MoveTree.

If promoting a piece by using the game.make(move: from:)  function, the game object does not know of the user selected piece after the promotion, nor does it update the move object at any point. 

So for example if we initialize a game object with the following fen: "4kb1r/Pb2qpp1/2pp1n1p/1rn1p3/4P3/1BNP1N2/2P2PPP/R1BQ1RK1 w k - 1 14"

the move pawn on a7 to a8 will be annotated by the SANParser as simply "a8" since the value for promotedPiece is nil. 

I didn't want to tie board and game objects because those should be able to operate independently, so I passed the responsibility of notifying the game object about the promoted piece to the developer.

----------------------
Those "revert" commits are removal of the bug fix changes in PR #51