### PR TITLE
Bug Fix - moves.endIndex is not updated after the first half move

### DIFF
--- a/Sources/ChessKit/MoveTree/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree.swift
@@ -56,6 +56,10 @@ public struct MoveTree: Hashable, Sendable {
       self.root = newNode
 
       dictionary = [index: newNode]
+        
+      if index.variation == Index.mainVariation {
+        lastMainVariationIndex = index
+      }
       return index
     }
 


### PR DESCRIPTION
A minor bug fix where moves.endIndex remains at .minimum after the first half move, since we are failing the guard statement and end in the else clause. 

This might cause unexpected behaviors such as with PR #52 where the first move is a promotion move and no index is provided. 

Simple solution, just update lastMainVariationIndex in the else statement as well. 