### PR TITLE
Bugfix - Incorrect minimum value when starting from black position

### DIFF
--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -16,8 +16,6 @@ public struct Game: Hashable, Sendable {
 
   /// The move tree representing all moves made in the game.
   public private(set) var moves: MoveTree
-  /// The move tree index of the starting position in the game.
-  public private(set) var startingIndex: MoveTree.Index
   /// A dictionary of every position in the game, keyed by move index.
   public private(set) var positions: [MoveTree.Index: Position]
   /// Contains the tag pairs for this game.
@@ -25,7 +23,13 @@ public struct Game: Hashable, Sendable {
 
   /// The starting position of the game.
   public var startingPosition: Position? {
-    positions[startingIndex]
+      positions[moves.startIndex]
+  }
+    
+  /// The move tree index of the starting position in the game.
+  @available(*, deprecated, message: "Use moves.startIndex instead")
+  public var startingIndex: MoveTree.Index {
+    moves.startIndex
   }
 
   // MARK: - Initializer
@@ -37,10 +41,10 @@ public struct Game: Hashable, Sendable {
   ///
   /// Defaults to the starting position.
   public init(startingWith position: Position = .standard, tags: Tags? = nil) {
-    let startingIndex = MoveTree.Index.getMinimum(for: position.sideToMove)
-      
     moves = MoveTree(firstSideToMove: position.sideToMove)
-    self.startingIndex = startingIndex
+    
+    let startingIndex = moves.startIndex
+      
     positions = [startingIndex: position]
     self.tags = tags ?? .init()
 
@@ -59,7 +63,6 @@ public struct Game: Hashable, Sendable {
     }
 
     moves = parsed.moves
-    startingIndex = parsed.startingIndex
     positions = parsed.positions
     tags = parsed.tags
   }

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -37,8 +37,9 @@ public struct Game: Hashable, Sendable {
   ///
   /// Defaults to the starting position.
   public init(startingWith position: Position = .standard, tags: Tags? = nil) {
-    moves = MoveTree()
-    let startingIndex = position.sideToMove == .white ? MoveTree.Index.minimum : .minimum.next
+    let startingIndex = MoveTree.Index.getMinimum(for: position.sideToMove)
+      
+    moves = MoveTree(firstSideToMove: position.sideToMove)
     self.startingIndex = startingIndex
     positions = [startingIndex: position]
     self.tags = tags ?? .init()
@@ -58,7 +59,7 @@ public struct Game: Hashable, Sendable {
     }
 
     moves = parsed.moves
-    startingIndex = .minimum
+    startingIndex = parsed.startingIndex
     positions = parsed.positions
     tags = parsed.tags
   }

--- a/Sources/ChessKit/MoveTree/MoveTree+Index.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree+Index.swift
@@ -31,14 +31,6 @@ extension MoveTree {
       self.variation = variation
     }
 
-    /// The minimum value of `MoveTree.Index(number: 0, color: .black)`
-    ///
-    /// This represents the starting position of the game.
-    ///
-    /// i.e. `MoveTree.Index(number: 1, color: .white)` is returned by `MoveTree.Index.minimum.next`
-    /// which is the first move of the game (played by white).
-    public static let minimum = Index(number: 0, color: .black)
-
     /// The previous index.
     ///
     /// This assumes `variation` is constant.
@@ -82,9 +74,21 @@ extension MoveTree {
         )
       }
     }
-
+    
+    /// The minimum value of `MoveTree.Index(number: 0, color: .black)` for white
+    /// and `MoveTree.Index(number: 1, color: .white)`
+    ///
+    /// This represents the starting position of the game, before the first move has been made.
+    ///
+    static func getMinimum(for firstToMove: Piece.Color = .white) -> Index {
+      return switch firstToMove {
+      case .white:
+          Index(number: 0, color: .black)
+      case .black:
+          Index(number: 1, color: .white)
+      }
+    }
   }
-
 }
 
 // MARK: - Comparable

--- a/Sources/ChessKit/MoveTree/MoveTree+Index.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree+Index.swift
@@ -80,7 +80,7 @@ extension MoveTree {
     ///
     /// This represents the starting position of the game, before the first move has been made.
     ///
-    static func getMinimum(for firstToMove: Piece.Color = .white) -> Index {
+    internal static func getMinimum(for firstToMove: Piece.Color = .white) -> Index {
       return switch firstToMove {
       case .white:
           Index(number: 0, color: .black)

--- a/Sources/ChessKit/MoveTree/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree.swift
@@ -23,7 +23,7 @@ public struct MoveTree: Hashable, Sendable {
   private(set) var dictionary: [Index: Node] = [:]
   /// The root node of the tree.
   private var root: Node?
-    
+  // The color to move first for the current game. 
   private let firstSideToMove: Piece.Color
 
   /// A set containing the indices of all the moves stored in the tree.

--- a/Sources/ChessKit/MoveTree/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree.swift
@@ -14,21 +14,28 @@ public struct MoveTree: Hashable, Sendable {
   /// The index of the root of the move tree.
   ///
   /// Defaults to `MoveTree.Index.minimum`.
-  var minimumIndex: Index = .minimum
+  var minimumIndex: Index
 
   /// The last index of the main variation of the move tree.
-  private(set) var lastMainVariationIndex: Index = .minimum
+  private(set) var lastMainVariationIndex: Index
 
   /// Dictionary representation of the tree for faster access.
   private(set) var dictionary: [Index: Node] = [:]
   /// The root node of the tree.
   private var root: Node?
+    
+  private let firstSideToMove: Piece.Color
 
   /// A set containing the indices of all the moves stored in the tree.
   public var indices: [Index] {
     Array(dictionary.keys)
   }
 
+  init(firstSideToMove: Piece.Color = .white) {
+    self.firstSideToMove = firstSideToMove
+    minimumIndex = MoveTree.Index.getMinimum(for: firstSideToMove)
+    lastMainVariationIndex = MoveTree.Index.getMinimum(for: firstSideToMove)
+  }
   /// Lock to restrict modification of tree nodes
   /// to ensure `Sendable` conformance for ``Node``.
   private static let nodeLock = NSLock()
@@ -113,7 +120,8 @@ public struct MoveTree: Hashable, Sendable {
   /// from the starting move until the move defined by `index`, accounting
   /// for any branching variations in between.
   public func history(for index: Index) -> [Index] {
-    let index = index == .minimum ? .minimum.next : index
+    let minimum = MoveTree.Index.getMinimum(for: firstSideToMove)
+    let index = index == minimum ? minimum.next : index
     var currentNode = dictionary[index]
     var history: [Index] = []
 
@@ -137,7 +145,8 @@ public struct MoveTree: Hashable, Sendable {
   /// from the move after the move defined by `index` to the last move
   /// of the variation.
   public func future(for index: Index) -> [Index] {
-    let index = index == .minimum ? .minimum.next : index
+    let minimum = MoveTree.Index.getMinimum(for: firstSideToMove)
+    let index = index == minimum ? minimum.next : index
     var currentNode = dictionary[index]
     var future: [Index] = []
 
@@ -358,7 +367,7 @@ extension MoveTree {
     /// The move for this node.
     var move: Move
     /// The index for this node.
-    fileprivate(set) var index: Index = .minimum
+    fileprivate(set) var index: Index = MoveTree.Index.getMinimum()
     /// The previous node.
     fileprivate(set) var previous: Node?
     /// The next node.

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -52,7 +52,7 @@ final class GameTests: XCTestCase {
   func testStartingPosition() {
     let game1 = Game(startingWith: .standard)
     XCTAssertEqual(
-      game1.startingIndex,
+      game1.moves.startIndex,
       .init(number: 0, color: .black, variation: 0)
     )
     XCTAssertEqual(game1.startingPosition, .standard)
@@ -61,11 +61,11 @@ final class GameTests: XCTestCase {
     var game2 = Game(startingWith: .init(fen: fen)!)
 
     XCTAssertEqual(
-      game2.startingIndex,
+      game2.moves.startIndex,
       .init(number: 1, color: .white, variation: 0)
     )
     XCTAssertEqual(game2.startingPosition, .init(fen: fen)!)
-    game2.make(move: "O-O", from: game2.startingIndex)
+    game2.make(move: "O-O", from: game2.moves.startIndex)
     XCTAssertEqual(
       game2.moves.index(after: game2.moves.minimumIndex),
       .init(number: 1, color: .black, variation: 0)

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -22,9 +22,10 @@ final class GameTests: XCTestCase {
   // MARK: - Setup
 
   override func setUp() {
+    let minimum = MoveTree.Index.getMinimum()
     game.tags = Self.mockTags
 
-    game.make(moves: ["e4", "e5", "Nf3", "Nc6", "Bc4"], from: .minimum)
+    game.make(moves: ["e4", "e5", "Nf3", "Nc6", "Bc4"], from: minimum)
 
     // add 2. Nc3 ... variation to 2. Nf3
     game.make(moves: ["Nc3", "Nf6", "Bc4"], from: nf3Index.previous)
@@ -36,8 +37,8 @@ final class GameTests: XCTestCase {
     game.make(moves: ["f5", "exf5"], from: nc6Index2.previous)
 
     // make repeat moves to test proper handling
-    game.make(move: "e4", from: .minimum)
-    game.make(move: "e5", from: .minimum.next)
+    game.make(move: "e4", from: minimum)
+    game.make(move: "e5", from: minimum.next)
     game.make(moves: ["Nc3", "Nf6"], from: nf3Index.previous)
   }
 
@@ -107,8 +108,8 @@ final class GameTests: XCTestCase {
       ),
       nf3Index
     )
-
-    XCTAssertEqual(game.moves.index(before: .minimum.next), .minimum)
+    let minimum = MoveTree.Index.getMinimum()
+    XCTAssertEqual(game.moves.index(before: minimum.next), minimum)
     XCTAssertEqual(game.moves.index(after: nc3Index), nf6Index)
   }
 

--- a/Tests/ChessKitTests/MoveTreeTests.swift
+++ b/Tests/ChessKitTests/MoveTreeTests.swift
@@ -9,29 +9,43 @@ import XCTest
 final class MoveTreeTests: XCTestCase {
 
   func testEmptyCollection() {
+    let minimum = MoveTree.Index.getMinimum()
     let moveTree = MoveTree()
+      
     XCTAssertTrue(moveTree.isEmpty)
-    XCTAssertEqual(moveTree.startIndex, .minimum)
-    XCTAssertEqual(moveTree.endIndex, .minimum)
+    XCTAssertEqual(moveTree.startIndex, minimum)
+    XCTAssertEqual(moveTree.endIndex, minimum)
 
-    XCTAssertFalse(moveTree.hasIndex(before: .minimum))
-    XCTAssertFalse(moveTree.hasIndex(after: .minimum))
+    XCTAssertFalse(moveTree.hasIndex(before: minimum))
+    XCTAssertFalse(moveTree.hasIndex(after: minimum))
   }
 
   func testSubscript() {
     var moveTree = MoveTree()
-    XCTAssertNil(moveTree[.minimum])
+    let minimum = MoveTree.Index.getMinimum()
+    XCTAssertNil(moveTree[minimum])
 
     let e4 = Move(san: "e4", position: .standard)
-    moveTree[.minimum.next] = e4
-    XCTAssertEqual(moveTree[.minimum.next], e4)
+    moveTree[minimum.next] = e4
+    XCTAssertEqual(moveTree[minimum.next], e4)
   }
 
-  func testNodeHashValue() {
+  func testNodeHashValueForWhite() {
     var moveTree = MoveTree()
+    let minimum = MoveTree.Index.getMinimum()
+
     let e4 = Move(san: "e4", position: .standard)
-    moveTree[.minimum.next] = e4
-    XCTAssertNotNil(moveTree.dictionary[.minimum.next]?.hashValue)
+    moveTree[minimum.next] = e4
+    XCTAssertNotNil(moveTree.dictionary[minimum.next]?.hashValue)
+  }
+
+  func testNodeHashValueForBlack() {
+    var moveTree = MoveTree(firstSideToMove: .black)
+    let minimum = MoveTree.Index.getMinimum(for: .black)
+    let position = Position(fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq - 0 1")! //Starting position, but black makes the first move
+    let e5 = Move(san: "e5", position: position)
+    moveTree[minimum.next] = e5
+    XCTAssertNotNil(moveTree.dictionary[minimum.next]?.hashValue)
   }
 
   func testSameVariationComparability() {
@@ -71,6 +85,7 @@ extension MoveTreeTests {
   @available(*, deprecated)
   func testDeprecated() {
     var moveTree = MoveTree()
+    let minimum = MoveTree.Index.getMinimum()
 
     let move1 = Move(san: "e4", position: .standard)!
     let move2 = Move(san: "e5", position: .init(fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 2")!)!
@@ -90,10 +105,10 @@ extension MoveTreeTests {
     XCTAssertEqual(moveTree.move(at: i2), moveTree[i2])
     XCTAssertEqual(moveTree.move(at: i2), move2)
 
-    XCTAssertNil(moveTree.previousIndex(for: .minimum))
+    XCTAssertNil(moveTree.previousIndex(for: minimum))
     XCTAssertNil(moveTree.nextIndex(for: i2))
 
-    XCTAssertEqual(moveTree.nextIndex(for: .minimum), i1)
+    XCTAssertEqual(moveTree.nextIndex(for: minimum), i1)
   }
 
 }


### PR DESCRIPTION
This PR fixes an issue where the move tree is represented incorrectly for games where we started from a position where black player makes the first move.

Consider the following fen:
rnbqk2r/pp2bppp/4pn2/2pp4/2PP1B2/2N2N1P/PP2PPP1/R2QKB1R b KQkq - 0 6

Black to move and plays cxd4
white responds with cxd5
black then plays Nxd5
and white plays Nxd5

With the current implementation white moves will be offset by 1 and the move tree would look like:

cxd5 cxd4
Nxd5 Nxd5
Where it should look like:

(empty) cxd4
cxd5 Nxd5
Nxd5 ....
This PR fixes the issue, by asking for a color to move first when providing the value for the minimum index which all other indices rely on.