### PR TITLE
Fix multiple `BoardDelegate.didPromote()` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * Fix issue where `MoveTree.endIndex` is not properly updated after the first half move (by [@Amir-Zucker](https://github.com/Amir-Zucker)).
 * Fix issue where `BoardDelegate.didPromote()` was called before and after promotion (by [@Amir-Zucker](https://github.com/Amir-Zucker)).
 
+### Breaking Changes
+* `Game(pgn:)` is no longer a failable initializer, it will now always create a non-`nil` `Game`.
+
 # ChessKit 0.13.0
 Released Thursday, October 3, 2024.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [unreleased]
+
+### New Features
+* Add `willPromote()` to `BoardDelegate` (by [@Amir-Zucker](https://github.com/Amir-Zucker)).
+  * Called when pawn reaches last rank but before `Board.completePromotion()` is called.
+
+### Bug Fixes
+* Fix issue where `MoveTree.endIndex` is not properly updated after the first half move (by [@Amir-Zucker](https://github.com/Amir-Zucker)).
+* Fix issue where `BoardDelegate.didPromote()` was called before and after promotion (by [@Amir-Zucker](https://github.com/Amir-Zucker)).
+
 # ChessKit 0.13.0
 Released Thursday, October 3, 2024.
 

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let package = Package(
     .macCatalyst(.v13),
     .macOS(.v10_15),
     .tvOS(.v13),
-    .watchOS(.v6)
+    .watchOS(.v6),
+    .visionOS(.v1)
   ],
   products: [
     .library(name: "ChessKit", targets: ["ChessKit"])

--- a/Sources/ChessKit/Bitboards/Attacks.swift
+++ b/Sources/ChessKit/Bitboards/Attacks.swift
@@ -194,7 +194,7 @@ struct Attacks: Sendable {
   /// Returns the possible moves for a sliding piece (bishop or rook)
   /// accounting for blocking pieces.
   ///
-  /// - Note: The first blocking piece encountered in each direction
+  /// - note: The first blocking piece encountered in each direction
   /// is included in the returned bitboard. It is up to the caller to handle
   /// captures or non-capturable pieces (i.e. same color pieces).
   private static func slidingAttacks(

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -7,6 +7,7 @@
 /// events related to changes in position on the board such
 /// as pawn promotions and end results.
 public protocol BoardDelegate: AnyObject, Sendable {
+  func willPromote(with move: Move)
   func didPromote(with move: Move)
   func didCheckKing(ofColor color: Piece.Color)
   func didEnd(with result: Board.EndResult)
@@ -241,7 +242,11 @@ public struct Board: Sendable {
     // pawn promotion
     if move.piece.kind == .pawn {
       if (move.end.rank == 8 && move.piece.color == .white) || (move.end.rank == 1 && move.piece.color == .black) {
-        delegate?.didPromote(with: move)
+        if move.promotedPiece == nil {
+          delegate?.willPromote(with: move)
+        } else {
+          delegate?.didPromote(with: move)
+        }
       }
     }
 

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -50,12 +50,8 @@ public struct Game: Hashable, Sendable {
   ///
   /// - parameter pgn: A string containing a PGN representation of
   /// a game.
-  ///
-  /// This initalizer fails if the PGN is invalid.
-  public init?(pgn: String) {
-    guard let parsed = PGNParser.parse(game: pgn) else {
-      return nil
-    }
+  public init(pgn: String) {
+    let parsed = PGNParser.parse(game: pgn)
 
     moves = parsed.moves
     startingIndex = .minimum

--- a/Sources/ChessKit/Move.swift
+++ b/Sources/ChessKit/Move.swift
@@ -21,9 +21,9 @@ public struct Move: Hashable, Sendable {
 
     var notation: String {
       switch self {
-      case .none, .stalemate: return ""
-      case .check: return "+"
-      case .checkmate: return "#"
+      case .none, .stalemate: ""
+      case .check: "+"
+      case .checkmate: "#"
       }
     }
   }

--- a/Sources/ChessKit/Move.swift
+++ b/Sources/ChessKit/Move.swift
@@ -91,7 +91,7 @@ public struct Move: Hashable, Sendable {
 
   /// The engine LAN represenation of the move.
   ///
-  /// NOTE: This is intended for engine communication
+  /// - note: This is intended for engine communication
   /// so piece names, capture/check indicators, etc. are not included.
   public var lan: String {
     EngineLANParser.convert(move: self)

--- a/Sources/ChessKit/Parsers/PGNParser.swift
+++ b/Sources/ChessKit/Parsers/PGNParser.swift
@@ -40,7 +40,7 @@ public enum PGNParser {
   public static func parse(
     game pgn: String,
     startingWith position: Position = .standard
-  ) -> Game? {
+  ) -> Game {
     // ignoring tag pairs for now, movetext only
 
     let processedPGN =
@@ -88,16 +88,12 @@ public enum PGNParser {
 
     let moveText: [String]
 
-    do {
-      moveText = try NSRegularExpression(pattern: Pattern.moveText)
-        .matches(in: processedPGN, range: range)
-        .map {
-          NSString(string: pgn).substring(with: $0.range)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-    } catch {
-      return nil
-    }
+    moveText = try! NSRegularExpression(pattern: Pattern.moveText)
+      .matches(in: processedPGN, range: range)
+      .map {
+        NSString(string: pgn).substring(with: $0.range)
+          .trimmingCharacters(in: .whitespacesAndNewlines)
+      }
 
     let parsedMoves = moveText.compactMap { move -> ParsedMove? in
       let range = NSRange(0..<move.utf16.count)

--- a/Sources/ChessKit/Parsers/SANParser.swift
+++ b/Sources/ChessKit/Parsers/SANParser.swift
@@ -103,13 +103,13 @@ public enum SANParser {
           .filter {
             switch disambiguation {
             case let .byFile(file):
-              return $0.square.file == file
+              $0.square.file == file
             case let .byRank(rank):
-              return $0.square.rank == rank
+              $0.square.rank == rank
             case let .bySquare(square):
-              return $0.square == square
+              $0.square == square
             case .none:
-              return true
+              true
             }
           }
           .first
@@ -197,9 +197,9 @@ public enum SANParser {
   ///
   private static func targetSquare(for san: String) -> Square? {
     if let range = san.range(of: Pattern.targetSquare, options: .regularExpression) {
-      return Square(String(san[range]))
+      Square(String(san[range]))
     } else {
-      return nil
+      nil
     }
   }
 

--- a/Sources/ChessKit/Piece.swift
+++ b/Sources/ChessKit/Piece.swift
@@ -85,7 +85,7 @@ public struct Piece: Hashable, Sendable {
 
   /// The FEN representation of the piece.
   ///
-  /// Note: This value does not convey any information regarding
+  /// - note: This value does not convey any information regarding
   /// the piece's location on the board (only kind and color).
   var fen: String {
     switch (color, kind) {

--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -119,7 +119,7 @@ public struct Position: Sendable {
   /// This function assumes castling is valid for the provided `castling`. If the the king move is
   /// valid, it will be performed whether or not there is actually a piece on the `rookStart` square.
   ///
-  /// - Note: The rook will only be moved if the king move succeeds.
+  /// - note: The rook will only be moved if the king move succeeds.
   ///
   @discardableResult
   mutating func castle(_ castling: Castling) -> Piece? {

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -39,20 +39,33 @@ final class BoardTests: XCTestCase {
     let queen = Piece(.queen, color: .white, square: .e8)
     var board = Board(position: .init(pieces: [pawn]))
 
-    nonisolated(unsafe) var expectation: XCTestExpectation? = self.expectation(description: "Board returns promotion move")
+    let willPromoteExpectation = self.expectation(
+      description: "Board will promote"
+    )
+    let didPromoteExpecatation = self.expectation(
+      description: "Board did promote"
+    )
 
-    let delegate = MockBoardDelegate(didPromote: { move in
-      let newPawn = Piece(.pawn, color: .white, square: .e8)
-      XCTAssertEqual(move.piece, newPawn)
-      expectation?.fulfill()
-      expectation = nil
-    })
+    let delegate = MockBoardDelegate(
+      willPromote: { [weak willPromoteExpectation] move in
+        let pawn = Piece(.pawn, color: .white, square: .e8)
+        XCTAssertEqual(move.piece, pawn)
+        XCTAssertNil(move.promotedPiece)
+        willPromoteExpectation?.fulfill()
+      },
+      didPromote: { [weak didPromoteExpecatation] move in
+        XCTAssertEqual(move.promotedPiece, queen)
+        didPromoteExpecatation?.fulfill()
+      }
+    )
     board.delegate = delegate
 
     let move = board.move(pieceAt: .e7, to: .e8)!
-    waitForExpectations(timeout: 1.0)
+    wait(for: [willPromoteExpectation], timeout: 1.0)
 
     let promotionMove = board.completePromotion(of: move, to: .queen)
+    wait(for: [didPromoteExpecatation], timeout: 1.0)
+
     XCTAssertEqual(promotionMove.result, .move)
     XCTAssertEqual(promotionMove.promotedPiece, queen)
     XCTAssertEqual(promotionMove.end, .e8)
@@ -63,20 +76,33 @@ final class BoardTests: XCTestCase {
     let queen = Piece(.queen, color: .black, square: .e1)
     var board = Board(position: .init(pieces: [pawn]))
 
-    nonisolated(unsafe) var expectation: XCTestExpectation? = self.expectation(description: "Board returns promotion move")
+    let willPromoteExpectation = self.expectation(
+      description: "Board will promote"
+    )
+    let didPromoteExpecatation = self.expectation(
+      description: "Board did promote"
+    )
 
-    let delegate = MockBoardDelegate(didPromote: { move in
-      let newPawn = Piece(.pawn, color: .black, square: .e1)
-      XCTAssertEqual(move.piece, newPawn)
-      expectation?.fulfill()
-      expectation = nil
-    })
+    let delegate = MockBoardDelegate(
+      willPromote: { [weak willPromoteExpectation] move in
+        let pawn = Piece(.pawn, color: .black, square: .e1)
+        XCTAssertEqual(move.piece, pawn)
+        XCTAssertNil(move.promotedPiece)
+        willPromoteExpectation?.fulfill()
+      },
+      didPromote: { [weak didPromoteExpecatation] move in
+        XCTAssertEqual(move.promotedPiece, queen)
+        didPromoteExpecatation?.fulfill()
+      }
+    )
     board.delegate = delegate
 
     let move = board.move(pieceAt: .e2, to: .e1)!
-    waitForExpectations(timeout: 1.0)
+    wait(for: [willPromoteExpectation], timeout: 1.0)
 
     let promotionMove = board.completePromotion(of: move, to: .queen)
+    wait(for: [didPromoteExpecatation], timeout: 1.0)
+
     XCTAssertEqual(promotionMove.result, .move)
     XCTAssertEqual(promotionMove.promotedPiece, queen)
     XCTAssertEqual(promotionMove.end, .e1)

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -13,6 +13,7 @@ final class GameTests: XCTestCase {
   // MARK: - Indices used in tests
 
   private let nf3Index = MoveTree.Index(number: 2, color: .white, variation: 0)
+  private let bc4Index = MoveTree.Index(number: 3, color: .white, variation: 0)
   private let nc3Index = MoveTree.Index(number: 2, color: .white, variation: 1)
   private let nf6Index = MoveTree.Index(number: 2, color: .black, variation: 1)
   private let nc6Index = MoveTree.Index(number: 2, color: .black, variation: 2)
@@ -84,6 +85,25 @@ final class GameTests: XCTestCase {
     XCTAssertEqual(game.moves[.init(number: 3, color: .white)]?.san, "Bc4")
   }
 
+  func testMakeInvalidMoves() {
+    let movesBefore = game.moves
+
+    XCTAssertEqual(
+      game.make(move: "e1", from: .init(number: 10, color: .black)),
+      .init(number: 10, color: .black)
+    )
+    // test that `MoveTree` has not changed
+    XCTAssertEqual(movesBefore, game.moves)
+
+    XCTAssertEqual(
+      game.make(
+        move: .init(san: "e4", position: .standard)!,
+        from: .init(number: 100, color: .white)
+      ),
+      .init(number: 100, color: .white)
+    )
+  }
+
   func testMoveTree() {
     XCTAssertEqual(game.moves[nf3Index]?.san, "Nf3")
     XCTAssertEqual(game.moves[nc3Index]?.san, "Nc3")
@@ -91,22 +111,12 @@ final class GameTests: XCTestCase {
     XCTAssertEqual(game.moves[nf6Index]?.san, "Nf6")
     XCTAssertEqual(game.moves[nc6Index]?.san, "Nc6")
 
-    XCTAssertEqual(
-      game.moves.index(
-        before: nc6Index
-      ),
-      nc3Index
-    )
+    XCTAssertEqual(game.moves.index(before: nc6Index), nc3Index)
 
     XCTAssertEqual(game.moves[nc6Index2]?.san, "Nc6")
     XCTAssertEqual(game.moves[f5Index]?.san, "f5")
 
-    XCTAssertEqual(
-      game.moves.index(
-        before: f5Index
-      ),
-      nf3Index
-    )
+    XCTAssertEqual(game.moves.index(before: f5Index), nf3Index)
 
     XCTAssertEqual(game.moves.index(before: .minimum.next), .minimum)
     XCTAssertEqual(game.moves.index(after: nc3Index), nf6Index)
@@ -290,7 +300,13 @@ final class GameTests: XCTestCase {
   }
 
   func testInvalidGame() {
+    let game = Game(pgn: "invalid pgn string")
+    XCTAssertNil(game)
+  }
 
+  func testGameWithPromotion() {
+    game.make(moves: ["f5", "d4", "fxe4", "d5", "exf3", "d6", "fxg2", "dxc7", "gxh1=Q+", "Ke2", "Nb4", "cxd8=Q+"], from: bc4Index)
+    XCTAssertTrue(game.moves.map(\.?.san).contains("gxh1=Q+"))
   }
 
 }

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -282,7 +282,7 @@ final class GameTests: XCTestCase {
       1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4
       """
 
-    let game = Game(pgn: pgn)!
+    let game = Game(pgn: pgn)
     XCTAssertTrue(game.tags.isValid)
   }
 
@@ -294,14 +294,9 @@ final class GameTests: XCTestCase {
       1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4
       """
 
-    let game = Game(pgn: pgn)!
+    let game = Game(pgn: pgn)
     XCTAssertFalse(game.tags.isValid)
     XCTAssertTrue(game.tags.$site.pgn.isEmpty)
-  }
-
-  func testInvalidGame() {
-    let game = Game(pgn: "invalid pgn string")
-    XCTAssertNil(game)
   }
 
   func testGameWithPromotion() {

--- a/Tests/ChessKitTests/MoveTreeTests.swift
+++ b/Tests/ChessKitTests/MoveTreeTests.swift
@@ -62,6 +62,12 @@ final class MoveTreeTests: XCTestCase {
     XCTAssertGreaterThan(bIndex1.previous, bIndex2.previous)
   }
 
+  func testNonexistentIndexBeforeAndAfter() {
+    let tree = MoveTree()
+    XCTAssertEqual(tree.index(after: .minimum), .minimum)
+    XCTAssertEqual(tree.index(before: .minimum), .minimum)
+  }
+
 }
 
 // MARK: - Deprecated Tests

--- a/Tests/ChessKitTests/Parsers/PGNParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/PGNParserTests.swift
@@ -19,79 +19,79 @@ final class PGNParserTests: XCTestCase {
     let game = PGNParser.parse(game: Game.fischerSpassky)
 
     // tags
-    XCTAssertEqual(game?.tags.event, "F/S Return Match")
-    XCTAssertEqual(game?.tags.site, "Belgrade, Serbia JUG")
-    XCTAssertEqual(game?.tags.date, "1992.11.04")
-    XCTAssertEqual(game?.tags.round, "29")
-    XCTAssertEqual(game?.tags.white, "Fischer, Robert J.")
-    XCTAssertEqual(game?.tags.black, "Spassky, Boris V.")
-    XCTAssertEqual(game?.tags.result, "1/2-1/2")
+    XCTAssertEqual(game.tags.event, "F/S Return Match")
+    XCTAssertEqual(game.tags.site, "Belgrade, Serbia JUG")
+    XCTAssertEqual(game.tags.date, "1992.11.04")
+    XCTAssertEqual(game.tags.round, "29")
+    XCTAssertEqual(game.tags.white, "Fischer, Robert J.")
+    XCTAssertEqual(game.tags.black, "Spassky, Boris V.")
+    XCTAssertEqual(game.tags.result, "1/2-1/2")
   }
 
   func testCustomTagParsing() {
     // invalid pair
     let g1 = PGNParser.parse(game: "[a] 1. e4 e5")
-    XCTAssertNil(g1?.tags.other["a"])
+    XCTAssertNil(g1.tags.other["a"])
 
     // custom tag
     let g2 = PGNParser.parse(game: "[CustomTag \"Value\"] 1. e4 e5")
-    XCTAssertEqual(g2?.tags.other["CustomTag"], "Value")
+    XCTAssertEqual(g2.tags.other["CustomTag"], "Value")
 
     // duplicate tags
     let g3 = PGNParser.parse(game: "[CustomTag \"Value\"] [CustomTag \"Value2\"] 1. e4 e5")
-    XCTAssertEqual(g3?.tags.other["CustomTag"], "Value")
+    XCTAssertEqual(g3.tags.other["CustomTag"], "Value")
   }
 
   func testMoveTextParsing() {
     let game = PGNParser.parse(game: Game.fischerSpassky)
 
     // starting position + 85 ply
-    XCTAssertEqual(game?.positions.keys.count, 86)
+    XCTAssertEqual(game.positions.keys.count, 86)
 
     XCTAssertEqual(
-      game?.moves[
+      game.moves[
         .init(
           number: 1,
           color: .white
         )]?.assessment, .blunder)
     XCTAssertEqual(
-      game?.moves[
+      game.moves[
         .init(
           number: 1,
           color: .black
         )]?.assessment, .brilliant)
     XCTAssertEqual(
-      game?.moves[
+      game.moves[
         .init(
           number: 3,
           color: .black
         )]?.comment, "This opening is called the Ruy Lopez.")
     XCTAssertEqual(
-      game?.moves[
+      game.moves[
         .init(
           number: 4,
           color: .white
         )]?.comment, "test comment")
     XCTAssertEqual(
-      game?.moves[
+      game.moves[
         .init(
           number: 10,
           color: .white
         )]?.end, .d4)
     XCTAssertEqual(
-      game?.moves[
+      game.moves[
         .init(
           number: 18,
           color: .black
         )]?.piece.kind, .queen)
     XCTAssertEqual(
-      game?.moves[
+      game.moves[
         .init(
           number: 18,
           color: .black
         )]?.end, .e7)
     XCTAssertEqual(
-      game?.moves[
+      game.moves[
         .init(
           number: 36,
           color: .white

--- a/Tests/ChessKitTests/Utilities/MockBoardDelegate.swift
+++ b/Tests/ChessKitTests/Utilities/MockBoardDelegate.swift
@@ -3,21 +3,28 @@
 //  ChessKit
 //
 
-@testable import ChessKit
+import ChessKit
 
 final class MockBoardDelegate: BoardDelegate {
+  private let willPromote: (@Sendable (Move) -> Void)?
   private let didPromote: (@Sendable (Move) -> Void)?
   private let didCheckKing: (@Sendable (Piece.Color) -> Void)?
   private let didEnd: (@Sendable (Board.EndResult) -> Void)?
 
   init(
+    willPromote: (@Sendable (Move) -> Void)? = nil,
     didPromote: (@Sendable (Move) -> Void)? = nil,
     didCheckKing: (@Sendable (Piece.Color) -> Void)? = nil,
     didEnd: (@Sendable (Board.EndResult) -> Void)? = nil
   ) {
+    self.willPromote = willPromote
     self.didPromote = didPromote
     self.didCheckKing = didCheckKing
     self.didEnd = didEnd
+  }
+
+  func willPromote(with move: Move) {
+    willPromote?(move)
   }
 
   func didPromote(with move: Move) {


### PR DESCRIPTION
* Added `BoardDelegate.willPromote()` which is called before user calls `Board.completePromotion()`
* Resolves issue where `BoardDelegate.didPromote()` was called before and after `Board.completePromotion()`
* Make `Game(pgn:)` initializer non-failable.