### PR TITLE
Migrate unit tests to Swift Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Improvements
 * `PGNParser` now parses `*` game results (indicating game in progress, abandoned, unknown, etc.).
+* Add `CustomStringConvertible` conformance to `Piece`, `Piece.Color`, and `Piece.Kind`.
+* Migrate all unit tests (expect performance tests) from `XCTest` to `Swift Testing`.
 
 ### Bug Fixes
 * Fix issue where `MoveTree.endIndex` is not properly updated after the first half move (by [@Amir-Zucker](https://github.com/Amir-Zucker)).

--- a/Sources/ChessKit/Piece.swift
+++ b/Sources/ChessKit/Piece.swift
@@ -122,3 +122,31 @@ public struct Piece: Hashable, Sendable {
   }
 
 }
+
+extension Piece: CustomStringConvertible {
+  public var description: String {
+    "\(String(describing: color)) \(String(describing: kind)) on \(square.notation)"
+  }
+}
+
+extension Piece.Color: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .white: "White"
+    case .black: "Black"
+    }
+  }
+}
+
+extension Piece.Kind: CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .pawn: "Pawn"
+    case .bishop: "Bishop"
+    case .knight: "Knight"
+    case .rook: "Rook"
+    case .queen: "Queen"
+    case .king: "King"
+    }
+  }
+}

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -4,152 +4,114 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class BoardTests: XCTestCase {
+struct BoardTests {
 
-  func testEnPassant() {
+  @Test func enPassant() {
     var board = Board(position: .ep)
     let ep = board.position.enPassant!
 
     let capturingPiece = board.position.piece(at: .f4)!
-    XCTAssertTrue(ep.couldBeCaptured(by: capturingPiece))
+    #expect(ep.couldBeCaptured(by: capturingPiece))
 
     let move = board.move(pieceAt: .f4, to: ep.captureSquare)!
-    XCTAssertEqual(move.result, .capture(ep.pawn))
+    #expect(move.result == .capture(ep.pawn))
   }
 
-  func testIllegalEnPassant() {
+  @Test func illegalEnPassant() {
     // fen position contains illegal en passant move
     let board = Board(position: .init(fen: "1nbqkbnr/1pp1pppp/8/r1Pp3K/p7/5P2/PP1PP1PP/RNBQ1BNR w k d6 0 8")!)
-    XCTAssertFalse(board.canMove(pieceAt: .c5, to: .d6))
+    #expect(!board.canMove(pieceAt: .c5, to: .d6))
   }
 
-  func testDoubleEnPassant() {
+  @Test func doubleEnPassant() {
     var board = Board(position: .init(fen: "kr6/2p5/8/1P1P4/8/1K6/8/8 b - - 0 1")!)
     board.move(pieceAt: .c7, to: .c5)
     // after this move only 1 out of 2 pawns can execute enPassant
-    XCTAssertFalse(board.canMove(pieceAt: .b5, to: .c6))
-    XCTAssertTrue(board.canMove(pieceAt: .d5, to: .c6))
-    XCTAssertTrue(board.position.enPassantIsPossible)
+    #expect(!board.canMove(pieceAt: .b5, to: .c6))
+    #expect(board.canMove(pieceAt: .d5, to: .c6))
+    #expect(board.position.enPassantIsPossible)
   }
 
-  @MainActor func testWhitePromotion() {
-    let pawn = Piece(.pawn, color: .white, square: .e7)
-    let queen = Piece(.queen, color: .white, square: .e8)
+  @Test(arguments: Piece.Color.allCases)
+  func promotion(color: Piece.Color) async throws {
+    let pawnStart = color == .white ? Square.e7 : .e2
+    let pawnEnd = color == .white ? Square.e8 : .e1
+
+    let pawn = Piece(.pawn, color: color, square: pawnStart)
+    let queen = Piece(.queen, color: color, square: pawnEnd)
     var board = Board(position: .init(pieces: [pawn]))
 
-    let willPromoteExpectation = self.expectation(
-      description: "Board will promote"
-    )
-    let didPromoteExpecatation = self.expectation(
-      description: "Board did promote"
-    )
+    try await confirmation("\(pawn) promotes to \(queen)", expectedCount: 2) { confirm in
+      nonisolated(unsafe) var willPromoteDidRun = false
 
-    let delegate = MockBoardDelegate(
-      willPromote: { [weak willPromoteExpectation] move in
-        let pawn = Piece(.pawn, color: .white, square: .e8)
-        XCTAssertEqual(move.piece, pawn)
-        XCTAssertNil(move.promotedPiece)
-        willPromoteExpectation?.fulfill()
-      },
-      didPromote: { [weak didPromoteExpecatation] move in
-        XCTAssertEqual(move.promotedPiece, queen)
-        didPromoteExpecatation?.fulfill()
-      }
-    )
-    board.delegate = delegate
+      let delegate = MockBoardDelegate(
+        willPromote: { move in
+          let pawn = Piece(.pawn, color: color, square: pawnEnd)
+          #expect(move.piece == pawn)
+          #expect(move.promotedPiece == nil)
+          willPromoteDidRun = true
+          confirm()
+        },
+        didPromote: { move in
+          if !willPromoteDidRun {
+            Issue.record("BoardDelegate.willPromote() did not run.")
+          }
 
-    let move = board.move(pieceAt: .e7, to: .e8)!
-    wait(for: [willPromoteExpectation], timeout: 1.0)
+          #expect(move.promotedPiece == queen)
+          confirm()
+        }
+      )
+      board.delegate = delegate
 
-    let promotionMove = board.completePromotion(of: move, to: .queen)
-    wait(for: [didPromoteExpecatation], timeout: 1.0)
+      let attemptedMove = board.move(pieceAt: pawnStart, to: pawnEnd)
+      let move = try #require(attemptedMove)
+      let promotionMove = board.completePromotion(of: move, to: .queen)
 
-    XCTAssertEqual(promotionMove.result, .move)
-    XCTAssertEqual(promotionMove.promotedPiece, queen)
-    XCTAssertEqual(promotionMove.end, .e8)
+      #expect(promotionMove.result == .move)
+      #expect(promotionMove.promotedPiece == queen)
+      #expect(promotionMove.end == pawnEnd)
+    }
   }
 
-  @MainActor func testBlackPromotion() {
-    let pawn = Piece(.pawn, color: .black, square: .e2)
-    let queen = Piece(.queen, color: .black, square: .e1)
-    var board = Board(position: .init(pieces: [pawn]))
-
-    let willPromoteExpectation = self.expectation(
-      description: "Board will promote"
-    )
-    let didPromoteExpecatation = self.expectation(
-      description: "Board did promote"
-    )
-
-    let delegate = MockBoardDelegate(
-      willPromote: { [weak willPromoteExpectation] move in
-        let pawn = Piece(.pawn, color: .black, square: .e1)
-        XCTAssertEqual(move.piece, pawn)
-        XCTAssertNil(move.promotedPiece)
-        willPromoteExpectation?.fulfill()
-      },
-      didPromote: { [weak didPromoteExpecatation] move in
-        XCTAssertEqual(move.promotedPiece, queen)
-        didPromoteExpecatation?.fulfill()
-      }
-    )
-    board.delegate = delegate
-
-    let move = board.move(pieceAt: .e2, to: .e1)!
-    wait(for: [willPromoteExpectation], timeout: 1.0)
-
-    let promotionMove = board.completePromotion(of: move, to: .queen)
-    wait(for: [didPromoteExpecatation], timeout: 1.0)
-
-    XCTAssertEqual(promotionMove.result, .move)
-    XCTAssertEqual(promotionMove.promotedPiece, queen)
-    XCTAssertEqual(promotionMove.end, .e1)
-  }
-
-  @MainActor func testFiftyMoveRule() {
+  @Test func fiftyMoveRule() async {
     var board = Board(position: .fiftyMove)
-    nonisolated(unsafe) var expectation: XCTestExpectation? = self.expectation(description: "Board returns fifty move draw result")
 
-    let delegate = MockBoardDelegate(didEnd: { result in
-      if case .draw(let drawType) = result {
-        if drawType == .fiftyMoves {
-          expectation?.fulfill()
-          expectation = nil
+    await confirmation("Board returns fifty move draw result") { confirm in
+      let delegate = MockBoardDelegate(didEnd: { result in
+        if case .draw(let drawType) = result {
+          if drawType == .fiftyMoves {
+            confirm()
+          }
         }
-      } else {
-        XCTFail()
-      }
-    })
-    board.delegate = delegate
+      })
 
-    board.move(pieceAt: .f7, to: .f8)
-    waitForExpectations(timeout: 1.0)
+      board.delegate = delegate
+      board.move(pieceAt: .f7, to: .f8)
+    }
   }
 
-  @MainActor func testInsufficientMaterial() {
+  @Test func insufficientMaterial() async throws {
     var board = Board(position: .init(fen: "k7/b6P/8/8/8/8/8/K7 w - - 0 1")!)
-    nonisolated(unsafe) var expectation: XCTestExpectation? = self.expectation(description: "Board returns insufficient material draw result")
 
-    let delegate = MockBoardDelegate(didEnd: { result in
-      if case .draw(let drawType) = result {
-        if drawType == .insufficientMaterial {
-          expectation?.fulfill()
-          expectation = nil
+    try await confirmation("Board returns insufficient material draw result") { confirm in
+      let delegate = MockBoardDelegate(didEnd: { result in
+        if case .draw(let drawType) = result {
+          if drawType == .insufficientMaterial {
+            confirm()
+          }
         }
-      } else {
-        XCTFail()
-      }
-    })
-    board.delegate = delegate
+      })
+      board.delegate = delegate
 
-    let move = board.move(pieceAt: .h7, to: .h8)!
-    board.completePromotion(of: move, to: .bishop)
-    waitForExpectations(timeout: 1.0)
+      let attemptedMove = board.move(pieceAt: .h7, to: .h8)
+      let move = try #require(attemptedMove)
+      board.completePromotion(of: move, to: .bishop)
+    }
   }
 
-  func testInsufficientMaterialScenarios() {
+  @Test func insufficientMaterialScenarios() {
     // different promotions
     let fen = "k7/7P/8/8/8/8/8/K7 w - - 0 1"
 
@@ -161,7 +123,7 @@ final class BoardTests: XCTestCase {
       let move = board.move(pieceAt: .h7, to: .h8)!
 
       board.completePromotion(of: move, to: p)
-      XCTAssertFalse(board.position.hasInsufficientMaterial)
+      #expect(!board.position.hasInsufficientMaterial)
     }
 
     for p in invalidPieces {
@@ -169,29 +131,29 @@ final class BoardTests: XCTestCase {
       let move = board.move(pieceAt: .h7, to: .h8)!
 
       board.completePromotion(of: move, to: p)
-      XCTAssertTrue(board.position.hasInsufficientMaterial)
+      #expect(board.position.hasInsufficientMaterial)
     }
 
-    // opposite color bishops VS same color bishops
+    // opposite color bishops vs same color bishops
     let fen2 = "k5B1/b7/1b6/8/8/8/8/K7 w - - 0 1"
     let fen3 = "k5B1/1b6/2b5/8/8/8/8/K7 w - - 0 1"
 
     let board2 = Board(position: .init(fen: fen2)!)
     let board3 = Board(position: .init(fen: fen3)!)
 
-    XCTAssertFalse(board2.position.hasInsufficientMaterial)
-    XCTAssertTrue(board3.position.hasInsufficientMaterial)
+    #expect(!board2.position.hasInsufficientMaterial)
+    #expect(board3.position.hasInsufficientMaterial)
 
     // before and after king takes Queen
     let fen4 = "k7/1Q6/8/8/8/8/8/K7 w - - 0 1"
     var board4 = Board(position: .init(fen: fen4)!)
 
-    XCTAssertFalse(board4.position.hasInsufficientMaterial)
+    #expect(!board4.position.hasInsufficientMaterial)
     board4.move(pieceAt: .a8, to: .b7)
-    XCTAssertTrue(board4.position.hasInsufficientMaterial)
+    #expect(board4.position.hasInsufficientMaterial)
   }
 
-  @MainActor func testThreefoldRepetition() {
+  @Test func threefoldRepetition() async {
     var board = Board(position: .standard)
 
     board.move(pieceAt: .e2, to: .e4)
@@ -208,302 +170,283 @@ final class BoardTests: XCTestCase {
 
     board.move(pieceAt: .f3, to: .g1)
 
-    nonisolated(unsafe) var expectation: XCTestExpectation? = self.expectation(description: "Board returns draw by repetition result")
-
-    let delegate = MockBoardDelegate(didEnd: { result in
-      if case .draw(let drawType) = result {
-        if drawType == .repetition {
-          expectation?.fulfill()
-          expectation = nil
+    await confirmation("Board returns draw by repetition result") { confirm in
+      let delegate = MockBoardDelegate(didEnd: { result in
+        if case .draw(let drawType) = result {
+          if drawType == .repetition {
+            confirm()
+          }
         }
-      } else {
-        XCTFail()
-      }
-    })
+      })
 
-    board.delegate = delegate
-    board.move(pieceAt: .f6, to: .g8)  // 3rd time position occurs
-
-    waitForExpectations(timeout: 1.0)
+      board.delegate = delegate
+      board.move(pieceAt: .f6, to: .g8)  // 3rd time position occurs
+    }
   }
 
-  func testLegalMovesForNonexistentPiece() {
+  @Test func legalMovesForNonexistentPiece() {
     let board = Board(position: .standard)
     // no piece at d4
     let legalMoves = board.legalMoves(forPieceAt: .d4)
-    XCTAssertEqual(legalMoves.count, 0)
+    #expect(legalMoves.isEmpty)
   }
 
-  func testLegalPawnMoves() {
+  @Test func legalPawnMoves() {
     let board = Board(position: .standard)
     let legalC2PawnMoves = board.legalMoves(forPieceAt: .c2)
-    XCTAssertEqual(legalC2PawnMoves.count, 2)
-    XCTAssertTrue(legalC2PawnMoves.contains(.c3))
-    XCTAssertTrue(legalC2PawnMoves.contains(.c4))
-    XCTAssertTrue(board.canMove(pieceAt: .c2, to: .c3))
-    XCTAssertTrue(board.canMove(pieceAt: .c2, to: .c4))
-    XCTAssertFalse(board.canMove(pieceAt: .c2, to: .c5))
+    #expect(legalC2PawnMoves.count == 2)
+    #expect(legalC2PawnMoves.contains(.c3))
+    #expect(legalC2PawnMoves.contains(.c4))
+    #expect(board.canMove(pieceAt: .c2, to: .c3))
+    #expect(board.canMove(pieceAt: .c2, to: .c4))
+    #expect(!board.canMove(pieceAt: .c2, to: .c5))
 
     let legalF7PawnMoves = board.legalMoves(forPieceAt: .f7)
-    XCTAssertEqual(legalF7PawnMoves.count, 2)
-    XCTAssertTrue(legalF7PawnMoves.contains(.f6))
-    XCTAssertTrue(legalF7PawnMoves.contains(.f5))
-    XCTAssertTrue(board.canMove(pieceAt: .f7, to: .f6))
-    XCTAssertTrue(board.canMove(pieceAt: .f7, to: .f5))
-    XCTAssertFalse(board.canMove(pieceAt: .f7, to: .f4))
+    #expect(legalF7PawnMoves.count == 2)
+    #expect(legalF7PawnMoves.contains(.f6))
+    #expect(legalF7PawnMoves.contains(.f5))
+    #expect(board.canMove(pieceAt: .f7, to: .f6))
+    #expect(board.canMove(pieceAt: .f7, to: .f5))
+    #expect(!board.canMove(pieceAt: .f7, to: .f4))
   }
 
-  func testLegalKnightMoves() {
+  @Test func legalKnightMoves() {
     let position = Position(fen: "N6N/8/4N3/8/2N5/5N2/3N4/N6N w - - 0 1")!
     let board = Board(position: position)
 
-    XCTAssertTrue(board.canMove(pieceAt: .a8, to: .b6))
-    XCTAssertTrue(board.canMove(pieceAt: .a8, to: .c7))
+    #expect(board.canMove(pieceAt: .a8, to: .b6))
+    #expect(board.canMove(pieceAt: .a8, to: .c7))
 
-    XCTAssertTrue(board.canMove(pieceAt: .h8, to: .f7))
-    XCTAssertTrue(board.canMove(pieceAt: .h8, to: .g6))
+    #expect(board.canMove(pieceAt: .h8, to: .f7))
+    #expect(board.canMove(pieceAt: .h8, to: .g6))
 
-    XCTAssertTrue(board.canMove(pieceAt: .a1, to: .b3))
-    XCTAssertTrue(board.canMove(pieceAt: .a1, to: .c2))
+    #expect(board.canMove(pieceAt: .a1, to: .b3))
+    #expect(board.canMove(pieceAt: .a1, to: .c2))
 
-    XCTAssertTrue(board.canMove(pieceAt: .h1, to: .f2))
-    XCTAssertTrue(board.canMove(pieceAt: .h1, to: .g3))
+    #expect(board.canMove(pieceAt: .h1, to: .f2))
+    #expect(board.canMove(pieceAt: .h1, to: .g3))
 
-    XCTAssertTrue(board.canMove(pieceAt: .c4, to: .a3))
-    XCTAssertTrue(board.canMove(pieceAt: .c4, to: .a5))
-    XCTAssertTrue(board.canMove(pieceAt: .c4, to: .b2))
-    XCTAssertTrue(board.canMove(pieceAt: .c4, to: .b6))
-    XCTAssertFalse(board.canMove(pieceAt: .c4, to: .d2))
-    XCTAssertTrue(board.canMove(pieceAt: .c4, to: .d6))
-    XCTAssertTrue(board.canMove(pieceAt: .c4, to: .e3))
-    XCTAssertTrue(board.canMove(pieceAt: .c4, to: .e5))
+    #expect(board.canMove(pieceAt: .c4, to: .a3))
+    #expect(board.canMove(pieceAt: .c4, to: .a5))
+    #expect(board.canMove(pieceAt: .c4, to: .b2))
+    #expect(board.canMove(pieceAt: .c4, to: .b6))
+    #expect(!board.canMove(pieceAt: .c4, to: .d2))
+    #expect(board.canMove(pieceAt: .c4, to: .d6))
+    #expect(board.canMove(pieceAt: .c4, to: .e3))
+    #expect(board.canMove(pieceAt: .c4, to: .e5))
 
-    XCTAssertTrue(board.canMove(pieceAt: .d2, to: .b1))
-    XCTAssertTrue(board.canMove(pieceAt: .d2, to: .b3))
-    XCTAssertFalse(board.canMove(pieceAt: .d2, to: .c4))
-    XCTAssertTrue(board.canMove(pieceAt: .d2, to: .e4))
-    XCTAssertFalse(board.canMove(pieceAt: .d2, to: .f3))
-    XCTAssertTrue(board.canMove(pieceAt: .d2, to: .f1))
+    #expect(board.canMove(pieceAt: .d2, to: .b1))
+    #expect(board.canMove(pieceAt: .d2, to: .b3))
+    #expect(!board.canMove(pieceAt: .d2, to: .c4))
+    #expect(board.canMove(pieceAt: .d2, to: .e4))
+    #expect(!board.canMove(pieceAt: .d2, to: .f3))
+    #expect(board.canMove(pieceAt: .d2, to: .f1))
   }
 
-  func testLegalBishopMoves() {
+  @Test func legalBishopMoves() {
     let position = Position(fen: "5bBb/8/8/pPpPpPpP/8/8/8/BbB5 w - - 0 1")!
     let board = Board(position: position)
 
-    XCTAssertTrue(board.canMove(pieceAt: .a1, to: .d4))
-    XCTAssertTrue(board.canMove(pieceAt: .a1, to: .e5))
-    XCTAssertFalse(board.canMove(pieceAt: .a1, to: .f6))
+    #expect(board.canMove(pieceAt: .a1, to: .d4))
+    #expect(board.canMove(pieceAt: .a1, to: .e5))
+    #expect(!board.canMove(pieceAt: .a1, to: .f6))
 
-    XCTAssertTrue(board.canMove(pieceAt: .b1, to: .e4))
-    XCTAssertTrue(board.canMove(pieceAt: .b1, to: .f5))
-    XCTAssertFalse(board.canMove(pieceAt: .b1, to: .g6))
+    #expect(board.canMove(pieceAt: .b1, to: .e4))
+    #expect(board.canMove(pieceAt: .b1, to: .f5))
+    #expect(!board.canMove(pieceAt: .b1, to: .g6))
 
-    XCTAssertTrue(board.canMove(pieceAt: .c1, to: .f4))
-    XCTAssertTrue(board.canMove(pieceAt: .c1, to: .g5))
-    XCTAssertFalse(board.canMove(pieceAt: .c1, to: .h8))
+    #expect(board.canMove(pieceAt: .c1, to: .f4))
+    #expect(board.canMove(pieceAt: .c1, to: .g5))
+    #expect(!board.canMove(pieceAt: .c1, to: .h8))
 
-    XCTAssertTrue(board.canMove(pieceAt: .f8, to: .d6))
-    XCTAssertFalse(board.canMove(pieceAt: .f8, to: .c5))
-    XCTAssertFalse(board.canMove(pieceAt: .f8, to: .b4))
+    #expect(board.canMove(pieceAt: .f8, to: .d6))
+    #expect(!board.canMove(pieceAt: .f8, to: .c5))
+    #expect(!board.canMove(pieceAt: .f8, to: .b4))
 
-    XCTAssertTrue(board.canMove(pieceAt: .g8, to: .e6))
-    XCTAssertFalse(board.canMove(pieceAt: .g8, to: .d5))
-    XCTAssertFalse(board.canMove(pieceAt: .g8, to: .c4))
+    #expect(board.canMove(pieceAt: .g8, to: .e6))
+    #expect(!board.canMove(pieceAt: .g8, to: .d5))
+    #expect(!board.canMove(pieceAt: .g8, to: .c4))
 
-    XCTAssertTrue(board.canMove(pieceAt: .h8, to: .f6))
-    XCTAssertFalse(board.canMove(pieceAt: .h8, to: .e5))
-    XCTAssertFalse(board.canMove(pieceAt: .h8, to: .d4))
+    #expect(board.canMove(pieceAt: .h8, to: .f6))
+    #expect(!board.canMove(pieceAt: .h8, to: .e5))
+    #expect(!board.canMove(pieceAt: .h8, to: .d4))
   }
 
-  func testLegalRookMoves() {
+  @Test func legalRookMoves() {
     let position = Position(fen: "r7/1r6/2r1p3/P7/p7/2R1P3/1R6/R7 w - - 0 1")!
     let board = Board(position: position)
 
     [.a4, .h1].forEach {
-      XCTAssertTrue(board.canMove(pieceAt: .a1, to: $0))
+      #expect(board.canMove(pieceAt: .a1, to: $0))
     }
 
-    XCTAssertFalse(board.canMove(pieceAt: .a1, to: .a5))
+    #expect(!board.canMove(pieceAt: .a1, to: .a5))
 
     [.a2, .b1, .b7, .h2].forEach {
-      XCTAssertTrue(board.canMove(pieceAt: .b2, to: $0))
+      #expect(board.canMove(pieceAt: .b2, to: $0))
     }
 
-    XCTAssertFalse(board.canMove(pieceAt: .b2, to: .b8))
+    #expect(!board.canMove(pieceAt: .b2, to: .b8))
   }
 
-  func testLegalQueenMoves() {
+  @Test func legalQueenMoves() {
     let position = Position(fen: "7k/8/2pP4/3qq3/3QQ3/4pP2/8/K7 w - - 0 1")!
     let board = Board(position: position)
 
-    [.b2, .c3, .e5].forEach { XCTAssertTrue(board.canMove(pieceAt: .d4, to: $0)) }
-    [.e3, .c4, .b4].forEach { XCTAssertFalse(board.canMove(pieceAt: .d4, to: $0)) }
+    [.b2, .c3, .e5].forEach { #expect(board.canMove(pieceAt: .d4, to: $0)) }
+    [.e3, .c4, .b4].forEach { #expect(!board.canMove(pieceAt: .d4, to: $0)) }
 
-    [.d4, .f6, .g7].forEach { XCTAssertTrue(board.canMove(pieceAt: .e5, to: $0)) }
-    [.d6, .e6, .g6].forEach { XCTAssertFalse(board.canMove(pieceAt: .e5, to: $0)) }
+    [.d4, .f6, .g7].forEach { #expect(board.canMove(pieceAt: .e5, to: $0)) }
+    [.d6, .e6, .g6].forEach { #expect(!board.canMove(pieceAt: .e5, to: $0)) }
 
-    [.d4, .e4, .a2].forEach { XCTAssertTrue(board.canMove(pieceAt: .d5, to: $0)) }
-    [.c6, .e5, .d7].forEach { XCTAssertFalse(board.canMove(pieceAt: .d5, to: $0)) }
+    [.d4, .e4, .a2].forEach { #expect(board.canMove(pieceAt: .d5, to: $0)) }
+    [.c6, .e5, .d7].forEach { #expect(!board.canMove(pieceAt: .d5, to: $0)) }
 
-    [.d5, .e5, .h7].forEach { XCTAssertTrue(board.canMove(pieceAt: .e4, to: $0)) }
-    [.e2, .d4, .f3].forEach { XCTAssertFalse(board.canMove(pieceAt: .e4, to: $0)) }
+    [.d5, .e5, .h7].forEach { #expect(board.canMove(pieceAt: .e4, to: $0)) }
+    [.e2, .d4, .f3].forEach { #expect(!board.canMove(pieceAt: .e4, to: $0)) }
   }
 
-  func testLegalKingMoves() {
+  @Test func legalKingMoves() {
     let position = Position(fen: "8/8/8/4p3/4K3/8/8/8 w - - 0 1")!
     let board = Board(position: position)
 
     [.d3, .d5, .f3, .f5, .e3, .e5].forEach {
-      XCTAssertTrue(board.canMove(pieceAt: .e4, to: $0))
+      #expect(board.canMove(pieceAt: .e4, to: $0))
     }
 
     [.d4, .f4].forEach {
-      XCTAssertFalse(board.canMove(pieceAt: .e4, to: $0))
+      #expect(!board.canMove(pieceAt: .e4, to: $0))
     }
   }
 
-  func testCaptureMove() {
+  @Test func captureMove() {
     var board = Board(position: .init(fen: "8/8/8/4p3/3P4/8/8/8 w - - 0 1")!)
     let move = board.move(pieceAt: .d4, to: .e5)
 
     let capturedPiece = Piece(.pawn, color: .black, square: .e5)
-    XCTAssertEqual(move?.result, .capture(capturedPiece))
+    #expect(move?.result == .capture(capturedPiece))
   }
 
-  func testIllegalMove() {
+  @Test func illegalMove() {
     var board = Board(position: .standard)
     let move = board.move(pieceAt: .d2, to: .d5)
-    XCTAssertNil(move)
+    #expect(move == nil)
   }
 
-  @MainActor func testCheckMove() {
+  @Test func checkMove() async {
     var board = Board(position: .init(fen: "k7/7R/8/8/8/8/K7/8 w - - 0 1")!)
 
-    nonisolated(unsafe) var expectation: XCTestExpectation? = self.expectation(description: "Board returns check result")
+    await confirmation("Board returns check result") { confirm in
+      let delegate = MockBoardDelegate(didCheckKing: { color in
+        if color == .black {
+          confirm()
+        }
+      })
 
-    let delegate = MockBoardDelegate(didCheckKing: { color in
-      if color == .black {
-        expectation?.fulfill()
-        expectation = nil
-      } else {
-        XCTFail()
-      }
-    })
-
-    board.delegate = delegate
-    let move = board.move(pieceAt: .h7, to: .h8)
-    XCTAssertEqual(move?.checkState, .check)
-
-    waitForExpectations(timeout: 1.0)
+      board.delegate = delegate
+      let move = board.move(pieceAt: .h7, to: .h8)
+      #expect(move?.checkState == .check)
+    }
   }
 
-  @MainActor func testCheckmateMove() {
+  @Test func checkmateMove() async {
     var board = Board(position: .init(fen: "k7/7R/6R1/8/8/8/K7/8 w - - 0 1")!)
 
-    nonisolated(unsafe) var expectation: XCTestExpectation? = self.expectation(description: "Board returns checkmate result")
+    await confirmation("Board returns checkmate result") { confirm in
+      let delegate = MockBoardDelegate(didEnd: { result in
+        if case .win(.white) = result {
+          confirm()
+        }
+      })
 
-    let delegate = MockBoardDelegate(didEnd: { result in
-      if case .win(.white) = result {
-        expectation?.fulfill()
-        expectation = nil
-      } else {
-        XCTFail()
-      }
-    })
-
-    board.delegate = delegate
-    let move = board.move(pieceAt: .g6, to: .g8)
-    XCTAssertEqual(move?.checkState, .checkmate)
-
-    waitForExpectations(timeout: 1.0)
+      board.delegate = delegate
+      let move = board.move(pieceAt: .g6, to: .g8)
+      #expect(move?.checkState == .checkmate)
+    }
   }
 
-  func testSideToMove() {
+  @Test func sideToMove() {
     var position = Position.standard
-    XCTAssertEqual(position.sideToMove, .white)
+    #expect(position.sideToMove == .white)
 
     position.move(pieceAt: .e2, to: .e4)
-    XCTAssertEqual(position.sideToMove, .black)
+    #expect(position.sideToMove == .black)
   }
 
-  func testDisambiguation() {
+  @Test func disambiguation() {
     var board = Board(position: Position(fen: "3r3r/8/4B3/R2n4/2B1Q2Q/8/8/R6Q w - - 0 1")!)
 
     let r1a3 = board.move(pieceAt: .a1, to: .a3)
     let rdf8 = board.move(pieceAt: .d8, to: .f8)
     let qh4e1 = board.move(pieceAt: .h4, to: .e1)
 
-    XCTAssertEqual(r1a3?.san, "R1a3")
-    XCTAssertEqual(rdf8?.san, "Rdf8")
-    XCTAssertEqual(qh4e1?.san, "Qh4e1")
+    #expect(r1a3?.san == "R1a3")
+    #expect(rdf8?.san == "Rdf8")
+    #expect(qh4e1?.san == "Qh4e1")
 
     let bf7 = board.move(pieceAt: .e6, to: .f7)
-    XCTAssertEqual(bf7?.san, "Bf7")
+    #expect(bf7?.san == "Bf7")
 
     let bfxd5 = board.move(pieceAt: .f7, to: .d5)
-    XCTAssertEqual(bfxd5?.san, "Bfxd5")
+    #expect(bfxd5?.san == "Bfxd5")
   }
 
-  func testPrint() {
+  @Test func print() {
     let board = Board()
 
     ChessKitConfiguration.printOptions.mode = .letter
-    XCTAssertEqual(
-      String(describing: board),
-      """
-      8 r n b q k b n r
-      7 p p p p p p p p
-      6 · · · · · · · ·
-      5 · · · · · · · ·
-      4 · · · · · · · ·
-      3 · · · · · · · ·
-      2 P P P P P P P P
-      1 R N B Q K B N R
-        a b c d e f g h
-      """)
+    #expect(
+      String(describing: board) == """
+        8 r n b q k b n r
+        7 p p p p p p p p
+        6 · · · · · · · ·
+        5 · · · · · · · ·
+        4 · · · · · · · ·
+        3 · · · · · · · ·
+        2 P P P P P P P P
+        1 R N B Q K B N R
+          a b c d e f g h
+        """)
 
     ChessKitConfiguration.printOptions.mode = .graphic
-    XCTAssertEqual(
-      String(describing: board),
-      """
-      8 ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜
-      7 ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E}
-      6 · · · · · · · ·
-      5 · · · · · · · ·
-      4 · · · · · · · ·
-      3 · · · · · · · ·
-      2 ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙
-      1 ♖ ♘ ♗ ♕ ♔ ♗ ♘ ♖
-        a b c d e f g h
-      """)
+    #expect(
+      String(describing: board) == """
+        8 ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜
+        7 ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E}
+        6 · · · · · · · ·
+        5 · · · · · · · ·
+        4 · · · · · · · ·
+        3 · · · · · · · ·
+        2 ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙
+        1 ♖ ♘ ♗ ♕ ♔ ♗ ♘ ♖
+          a b c d e f g h
+        """)
 
     let bb = board.position.pieceSet.all
-    XCTAssertEqual(
-      bb.chessString(),
-      """
-      8 ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
-      7 ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
-      6 · · · · · · · ·
-      5 · · · · · · · ·
-      4 · · · · · · · ·
-      3 · · · · · · · ·
-      2 ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
-      1 ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
-        a b c d e f g h
-      """)
+    #expect(
+      bb.chessString() == """
+        8 ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
+        7 ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
+        6 · · · · · · · ·
+        5 · · · · · · · ·
+        4 · · · · · · · ·
+        3 · · · · · · · ·
+        2 ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
+        1 ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
+          a b c d e f g h
+        """)
 
-    XCTAssertEqual(
-      bb.chessString(labelRanks: false, labelFiles: false),
-      """
-      ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
-      ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
-      · · · · · · · ·
-      · · · · · · · ·
-      · · · · · · · ·
-      · · · · · · · ·
-      ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
-      ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
-      """)
+    #expect(
+      bb.chessString(labelRanks: false, labelFiles: false) == """
+        ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
+        ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
+        · · · · · · · ·
+        · · · · · · · ·
+        · · · · · · · ·
+        · · · · · · · ·
+        ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
+        ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯ ⨯
+        """)
   }
 
 }
@@ -513,40 +456,38 @@ final class BoardTests: XCTestCase {
 extension BoardTests {
 
   @available(*, deprecated)
-  func testPrintDeprecated() {
+  @Test func printDeprecated() {
     let board = Board()
 
     ChessKitConfiguration.printMode = .letter
-    XCTAssertEqual(ChessKitConfiguration.printMode, .letter)
-    XCTAssertEqual(
-      String(describing: board),
-      """
-      8 r n b q k b n r
-      7 p p p p p p p p
-      6 · · · · · · · ·
-      5 · · · · · · · ·
-      4 · · · · · · · ·
-      3 · · · · · · · ·
-      2 P P P P P P P P
-      1 R N B Q K B N R
-        a b c d e f g h
-      """)
+    #expect(ChessKitConfiguration.printMode == .letter)
+    #expect(
+      String(describing: board) == """
+        8 r n b q k b n r
+        7 p p p p p p p p
+        6 · · · · · · · ·
+        5 · · · · · · · ·
+        4 · · · · · · · ·
+        3 · · · · · · · ·
+        2 P P P P P P P P
+        1 R N B Q K B N R
+          a b c d e f g h
+        """)
 
     ChessKitConfiguration.printMode = .graphic
-    XCTAssertEqual(ChessKitConfiguration.printMode, .graphic)
-    XCTAssertEqual(
-      String(describing: board),
-      """
-      8 ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜
-      7 ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E}
-      6 · · · · · · · ·
-      5 · · · · · · · ·
-      4 · · · · · · · ·
-      3 · · · · · · · ·
-      2 ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙
-      1 ♖ ♘ ♗ ♕ ♔ ♗ ♘ ♖
-        a b c d e f g h
-      """)
+    #expect(ChessKitConfiguration.printMode == .graphic)
+    #expect(
+      String(describing: board) == """
+        8 ♜ ♞ ♝ ♛ ♚ ♝ ♞ ♜
+        7 ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E} ♟\u{FE0E}
+        6 · · · · · · · ·
+        5 · · · · · · · ·
+        4 · · · · · · · ·
+        3 · · · · · · · ·
+        2 ♙ ♙ ♙ ♙ ♙ ♙ ♙ ♙
+        1 ♖ ♘ ♗ ♕ ♔ ♗ ♘ ♖
+          a b c d e f g h
+        """)
   }
 
 }

--- a/Tests/ChessKitTests/CastlingTests.swift
+++ b/Tests/ChessKitTests/CastlingTests.swift
@@ -4,27 +4,27 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class CastlingTests: XCTestCase {
+struct CastlingTests {
 
-  func testCastling() {
+  @Test func castling() {
     var board = Board(position: .castling)
-    XCTAssertTrue(board.position.legalCastlings.contains(.bK))
-    XCTAssertFalse(board.position.legalCastlings.contains(.wK))
-    XCTAssertFalse(board.position.legalCastlings.contains(.bQ))
-    XCTAssertTrue(board.position.legalCastlings.contains(.wQ))
+    #expect(board.position.legalCastlings.contains(.bK))
+    #expect(!board.position.legalCastlings.contains(.wK))
+    #expect(!board.position.legalCastlings.contains(.bQ))
+    #expect(board.position.legalCastlings.contains(.wQ))
 
     // white queenside castle
     let wQmove = board.move(pieceAt: .e1, to: .c1)!
-    XCTAssertEqual(wQmove.result, .castle(.wQ))
+    #expect(wQmove.result == .castle(.wQ))
 
     // black kingside castle
     let bkMove = board.move(pieceAt: .e8, to: .g8)!
-    XCTAssertEqual(bkMove.result, .castle(.bK))
+    #expect(bkMove.result == .castle(.bK))
   }
 
-  func testInvalidCastling() {
+  @Test func invalidCastling() {
     let position = Position(
       pieces: [
         .init(.queen, color: .black, square: .e8),
@@ -35,18 +35,18 @@ final class CastlingTests: XCTestCase {
     var board = Board(position: position)
 
     // attempt to castle while in check
-    XCTAssertFalse(board.canMove(pieceAt: .e1, to: .g1))
+    #expect(!board.canMove(pieceAt: .e1, to: .g1))
 
     // attempt to castle through check
     board.move(pieceAt: .e8, to: .f8)
-    XCTAssertFalse(board.canMove(pieceAt: .e1, to: .g1))
+    #expect(!board.canMove(pieceAt: .e1, to: .g1))
 
     // valid castling move
     board.move(pieceAt: .f8, to: .h8)
-    XCTAssertTrue(board.canMove(pieceAt: .e1, to: .g1))
+    #expect(board.canMove(pieceAt: .e1, to: .g1))
   }
 
-  func testInvalidCastlingThroughPiece() {
+  @Test func invalidCastlingThroughPiece() {
     let position = Position(
       pieces: [
         .init(.bishop, color: .white, square: .f1),
@@ -57,11 +57,11 @@ final class CastlingTests: XCTestCase {
     var board = Board(position: position)
 
     // attempt to castle through another piece
-    XCTAssertFalse(board.canMove(pieceAt: .e1, to: .g1))
+    #expect(!board.canMove(pieceAt: .e1, to: .g1))
 
     // valid castling move
     board.move(pieceAt: .f1, to: .c4)
-    XCTAssertTrue(board.canMove(pieceAt: .e1, to: .g1))
+    #expect(board.canMove(pieceAt: .e1, to: .g1))
   }
 
 }

--- a/Tests/ChessKitTests/GameTests.swift
+++ b/Tests/ChessKitTests/GameTests.swift
@@ -4,9 +4,9 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class GameTests: XCTestCase {
+final class GameTests {
 
   private var game = Game()
 
@@ -22,7 +22,7 @@ final class GameTests: XCTestCase {
 
   // MARK: - Setup
 
-  override func setUp() {
+  init() {
     game.tags = Self.mockTags
 
     game.make(moves: ["e4", "e5", "Nf3", "Nc6", "Bc4"], from: .minimum)
@@ -42,132 +42,111 @@ final class GameTests: XCTestCase {
     game.make(moves: ["Nc3", "Nf6"], from: nf3Index.previous)
   }
 
-  override func tearDown() {
+  deinit {
     // reset game
     game = Game()
   }
 
   // MARK: - Test cases
 
-  func testStartingPosition() {
+  @Test func startingPosition() {
     let game1 = Game(startingWith: .standard)
-    XCTAssertEqual(
-      game1.startingIndex,
-      .init(number: 0, color: .black, variation: 0)
-    )
-    XCTAssertEqual(game1.startingPosition, .standard)
+    #expect(game1.startingIndex == .init(number: 0, color: .black, variation: 0))
+    #expect(game1.startingPosition == .standard)
 
     let fen = "r1bqkb1r/pp1ppppp/2n2n2/8/2B1P3/2N2N2/PP3PPP/R1BQK2R b KQkq - 4 6"
     var game2 = Game(startingWith: .init(fen: fen)!)
+    #expect(game2.startingIndex == .init(number: 1, color: .white, variation: 0))
+    #expect(game2.startingPosition == .init(fen: fen)!)
 
-    XCTAssertEqual(
-      game2.startingIndex,
-      .init(number: 1, color: .white, variation: 0)
-    )
-    XCTAssertEqual(game2.startingPosition, .init(fen: fen)!)
     game2.make(move: "O-O", from: game2.startingIndex)
-    XCTAssertEqual(
-      game2.moves.index(after: game2.moves.minimumIndex),
-      .init(number: 1, color: .black, variation: 0)
-    )
-    XCTAssertEqual(
-      game2.moves[.init(number: 1, color: .black, variation: 0)],
-      .init(san: "O-O", position: .init(fen: fen)!)
-    )
+    #expect(game2.moves.index(after: game2.moves.minimumIndex) == .init(number: 1, color: .black, variation: 0))
+    #expect(game2.moves[.init(number: 1, color: .black, variation: 0)] == .init(san: "O-O", position: .init(fen: fen)!))
   }
 
-  func testMakeMoves() {
-    XCTAssertFalse(game.moves.isEmpty)
-    XCTAssertEqual(game.moves[.init(number: 1, color: .white)]?.san, "e4")
-    XCTAssertEqual(game.moves[.init(number: 1, color: .black)]?.san, "e5")
-    XCTAssertEqual(game.moves[.init(number: 2, color: .white)]?.san, "Nf3")
-    XCTAssertEqual(game.moves[.init(number: 2, color: .black)]?.san, "Nc6")
-    XCTAssertEqual(game.moves[.init(number: 3, color: .white)]?.san, "Bc4")
+  @Test func validMoves() {
+    #expect(!game.moves.isEmpty)
+    #expect(game.moves[.init(number: 1, color: .white)]?.san == "e4")
+    #expect(game.moves[.init(number: 1, color: .black)]?.san == "e5")
+    #expect(game.moves[.init(number: 2, color: .white)]?.san == "Nf3")
+    #expect(game.moves[.init(number: 2, color: .black)]?.san == "Nc6")
+    #expect(game.moves[.init(number: 3, color: .white)]?.san == "Bc4")
   }
 
-  func testMakeInvalidMoves() {
+  @Test func invalidMoves() {
     let movesBefore = game.moves
 
-    XCTAssertEqual(
-      game.make(move: "e1", from: .init(number: 10, color: .black)),
-      .init(number: 10, color: .black)
-    )
+    #expect(game.make(move: "e1", from: .init(number: 10, color: .black)) == .init(number: 10, color: .black))
     // test that `MoveTree` has not changed
-    XCTAssertEqual(movesBefore, game.moves)
+    #expect(movesBefore == game.moves)
 
-    XCTAssertEqual(
+    #expect(
       game.make(
         move: .init(san: "e4", position: .standard)!,
         from: .init(number: 100, color: .white)
-      ),
-      .init(number: 100, color: .white)
+      ) == .init(number: 100, color: .white)
     )
   }
 
-  func testMoveTree() {
-    XCTAssertEqual(game.moves[nf3Index]?.san, "Nf3")
-    XCTAssertEqual(game.moves[nc3Index]?.san, "Nc3")
+  @Test func moveTree() {
+    #expect(game.moves[nf3Index]?.san == "Nf3")
+    #expect(game.moves[nc3Index]?.san == "Nc3")
 
-    XCTAssertEqual(game.moves[nf6Index]?.san, "Nf6")
-    XCTAssertEqual(game.moves[nc6Index]?.san, "Nc6")
+    #expect(game.moves[nf6Index]?.san == "Nf6")
+    #expect(game.moves[nc6Index]?.san == "Nc6")
 
-    XCTAssertEqual(game.moves.index(before: nc6Index), nc3Index)
+    #expect(game.moves.index(before: nc6Index) == nc3Index)
 
-    XCTAssertEqual(game.moves[nc6Index2]?.san, "Nc6")
-    XCTAssertEqual(game.moves[f5Index]?.san, "f5")
+    #expect(game.moves[nc6Index2]?.san == "Nc6")
+    #expect(game.moves[f5Index]?.san == "f5")
 
-    XCTAssertEqual(game.moves.index(before: f5Index), nf3Index)
+    #expect(game.moves.index(before: f5Index) == nf3Index)
 
-    XCTAssertEqual(game.moves.index(before: .minimum.next), .minimum)
-    XCTAssertEqual(game.moves.index(after: nc3Index), nf6Index)
+    #expect(game.moves.index(before: .minimum.next) == .minimum)
+    #expect(game.moves.index(after: nc3Index) == nf6Index)
   }
 
-  func testMoveAnnotation() {
+  @Test func moveAnnotation() {
     game.annotate(moveAt: nc3Index, assessment: .brilliant)
     game.annotate(moveAt: f5Index, comment: "Comment test")
 
-    XCTAssertEqual(
-      PGNParser.convert(game: game).split(separator: "\n").last,
-      "1. e4 e5 2. Nf3 (2. Nc3 $3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 {Comment test} 3. exf5) 3. Bc4"
-    )
+    let moveText = String(PGNParser.convert(game: game).split(separator: "\n").last!)
+    let expectedMoveText = "1. e4 e5 2. Nf3 (2. Nc3 $3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 {Comment test} 3. exf5) 3. Bc4"
+
+    #expect(moveText == expectedMoveText)
   }
 
-  func testMoveHistory() {
+  @Test func moveHistory() {
     let f5History = game.moves.history(for: f5Index)
+    let expectedF5History = [
+      .init(number: 1, color: .white, variation: 0),
+      .init(number: 1, color: .black, variation: 0),
+      .init(number: 2, color: .white, variation: 0),
+      f5Index
+    ]
 
-    XCTAssertEqual(
-      f5History,
-      [
-        .init(number: 1, color: .white, variation: 0),
-        .init(number: 1, color: .black, variation: 0),
-        .init(number: 2, color: .white, variation: 0),
-        f5Index
-      ]
-    )
+    #expect(f5History == expectedF5History)
   }
 
-  func testMoveFuture() {
+  @Test func moveFuture() {
     let f5Future = game.moves.future(for: f5Index)
+    let expectedF5Future = [MoveTree.Index(number: 3, color: .white, variation: 3)]
 
-    XCTAssertEqual(
-      f5Future,
-      [.init(number: 3, color: .white, variation: 3)]
-    )
+    #expect(f5Future == expectedF5Future)
   }
 
-  func testMoveFullVariation() {
+  @Test func moveFullVariation() {
     let f5History = game.moves.history(for: f5Index)
     let f5Future = game.moves.future(for: f5Index)
-
     let f5Full = game.moves.fullVariation(for: f5Index)
-    XCTAssertEqual(f5History + f5Future, f5Full)
+    #expect(f5History + f5Future == f5Full)
   }
 
-  func testMoveTreeEmptyPath() {
-    XCTAssertTrue(game.moves.path(from: nc3Index, to: nc3Index).isEmpty)
+  @Test func moveTreeEmptyPath() {
+    #expect(game.moves.path(from: nc3Index, to: nc3Index).isEmpty)
   }
 
-  func testMoveTreeSimplePath() {
+  @Test func moveTreeSimplePath() {
     // "1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4"
     let f4 = MoveTree.Index(number: 3, color: .white, variation: 2)
     let e5 = MoveTree.Index(number: 1, color: .black, variation: 0)
@@ -175,14 +154,10 @@ final class GameTests: XCTestCase {
     // 3. f4 to 1. e5
     let path1 = game.moves.path(from: f4, to: e5)
 
-    XCTAssertEqual(
-      path1.map(\.direction),
-      [.reverse, .reverse, .reverse]
-    )
+    #expect(path1.map(\.direction) == [.reverse, .reverse, .reverse])
 
-    XCTAssertEqual(
-      path1.map(\.index),
-      [
+    #expect(
+      path1.map(\.index) == [
         f4,
         .init(number: 2, color: .black, variation: 2),
         .init(number: 2, color: .white, variation: 1)
@@ -192,14 +167,10 @@ final class GameTests: XCTestCase {
     // 1. e5 to 3. f4
     let path2 = game.moves.path(from: e5, to: f4)
 
-    XCTAssertEqual(
-      path2.map(\.direction),
-      [.forward, .forward, .forward]
-    )
+    #expect(path2.map(\.direction) == [.forward, .forward, .forward])
 
-    XCTAssertEqual(
-      path2.map(\.index),
-      [
+    #expect(
+      path2.map(\.index) == [
         .init(number: 2, color: .white, variation: 1),
         .init(number: 2, color: .black, variation: 2),
         f4
@@ -207,16 +178,15 @@ final class GameTests: XCTestCase {
     )
   }
 
-  func testMoveTreeComplexPath() {
+  @Test func moveTreeComplexPath() {
     // "1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4"
     // 3. f4 to 3. Bc4
     let f4 = MoveTree.Index(number: 3, color: .white, variation: 2)
     let Bc4 = MoveTree.Index(number: 3, color: .white, variation: 0)
     let path = game.moves.path(from: f4, to: Bc4)
 
-    XCTAssertEqual(
-      path.map(\.direction),
-      [
+    #expect(
+      path.map(\.direction) == [
         .reverse,
         .reverse,
         .reverse,
@@ -227,9 +197,8 @@ final class GameTests: XCTestCase {
       ]
     )
 
-    XCTAssertEqual(
-      path.map(\.index),
-      [
+    #expect(
+      path.map(\.index) == [
         f4,
         .init(number: 2, color: .black, variation: 2),
         .init(number: 2, color: .white, variation: 1),
@@ -241,7 +210,7 @@ final class GameTests: XCTestCase {
     )
   }
 
-  func testPGN() {
+  @Test func pgn() {
     let pgn =
       """
       [Event "Test Event"]
@@ -265,10 +234,10 @@ final class GameTests: XCTestCase {
       1. e4 e5 2. Nf3 (2. Nc3 Nf6 (2... Nc6 3. f4) 3. Bc4) Nc6 (2... f5 3. exf5) 3. Bc4
       """
 
-    XCTAssertEqual(game.pgn, pgn)
+    #expect(game.pgn == pgn)
   }
 
-  func testValidTagPairs() {
+  @Test func validTagPairs() {
     let pgn =
       """
       [Event "Test Event"]
@@ -283,10 +252,10 @@ final class GameTests: XCTestCase {
       """
 
     let game = Game(pgn: pgn)
-    XCTAssertTrue(game.tags.isValid)
+    #expect(game.tags.isValid)
   }
 
-  func testInvalidTagPairs() {
+  @Test func invalidTagPairs() {
     let pgn =
       """
       [Event "Test Event"]
@@ -295,13 +264,13 @@ final class GameTests: XCTestCase {
       """
 
     let game = Game(pgn: pgn)
-    XCTAssertFalse(game.tags.isValid)
-    XCTAssertTrue(game.tags.$site.pgn.isEmpty)
+    #expect(!game.tags.isValid)
+    #expect(game.tags.$site.pgn.isEmpty)
   }
 
-  func testGameWithPromotion() {
+  @Test func gameWithPromotion() {
     game.make(moves: ["f5", "d4", "fxe4", "d5", "exf3", "d6", "fxg2", "dxc7", "gxh1=Q+", "Ke2", "Nb4", "cxd8=Q+"], from: bc4Index)
-    XCTAssertTrue(game.moves.map(\.?.san).contains("gxh1=Q+"))
+    #expect(game.moves.map(\.?.san).contains("gxh1=Q+"))
   }
 
 }

--- a/Tests/ChessKitTests/MoveTests.swift
+++ b/Tests/ChessKitTests/MoveTests.swift
@@ -4,96 +4,96 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class MoveTests: XCTestCase {
+struct MoveTests {
 
-  func testMoveSANInit() {
+  @Test func moveSANInit() {
     let move = Move(result: .move, piece: .init(.pawn, color: .white, square: .e4), start: .e2, end: .e4)
     let moveFromSAN = Move(san: "e4", position: .standard)
 
-    XCTAssertEqual(move, moveFromSAN)
+    #expect(move == moveFromSAN)
   }
 
-  func testMoveInvalidSANInit() {
-    XCTAssertNil(Move(san: "e5", position: .standard))
+  @Test func moveInvalidSANInit() {
+    #expect(Move(san: "e5", position: .standard) == nil)
   }
 
-  func testMoveNotation() {
+  @Test func moveNotation() {
     let pawnD3 = Move(result: .move, piece: Piece(.pawn, color: .white, square: .d3), start: .d2, end: .d3)
-    XCTAssertEqual(pawnD3.san, "d3")
-    XCTAssertEqual(pawnD3.lan, "d2d3")
+    #expect(pawnD3.san == "d3")
+    #expect(pawnD3.lan == "d2d3")
 
     let bishopF4 = Move(result: .move, piece: Piece(.bishop, color: .white, square: .f4), start: .c1, end: .f4)
-    XCTAssertEqual(bishopF4.san, "Bf4")
-    XCTAssertEqual(bishopF4.lan, "c1f4")
+    #expect(bishopF4.san == "Bf4")
+    #expect(bishopF4.lan == "c1f4")
   }
 
-  func testCaptureNotation() {
+  @Test func captureNotation() {
     let capturedPiece = Piece(.bishop, color: .black, square: .d5)
     let capturingPiece = Piece(.pawn, color: .white, square: .e4)
     let capture = Move(result: .capture(capturedPiece), piece: capturingPiece, start: .e4, end: .d5)
-    XCTAssertEqual(capture.san, "exd5")
-    XCTAssertEqual(capture.lan, "e4d5")
+    #expect(capture.san == "exd5")
+    #expect(capture.lan == "e4d5")
   }
 
-  func testEnPassantNotation() {
+  @Test func enPassantNotation() {
     let ep = EnPassant(pawn: Piece(.pawn, color: .black, square: .d5))
     let move = Move(result: .capture(ep.pawn), piece: Piece(.pawn, color: .white, square: .e5), start: .e5, end: .d6)
-    XCTAssertEqual(move.san, "exd6")
-    XCTAssertEqual(move.lan, "e5d6")
+    #expect(move.san == "exd6")
+    #expect(move.lan == "e5d6")
   }
 
-  func testCastlingNotation() {
+  @Test func castlingNotation() {
     let shortCastle = Move(result: .castle(.bK), piece: Piece(.king, color: .black, square: .e8), start: .e8, end: .g8)
-    XCTAssertEqual(shortCastle.san, "O-O")
-    XCTAssertEqual(shortCastle.lan, "e8g8")
+    #expect(shortCastle.san == "O-O")
+    #expect(shortCastle.lan == "e8g8")
 
     let longCastle = Move(result: .castle(.bQ), piece: Piece(.king, color: .black, square: .e8), start: .e8, end: .c8, checkState: .checkmate)
-    XCTAssertEqual(longCastle.san, "O-O-O#")
-    XCTAssertEqual(longCastle.lan, "e8c8")
+    #expect(longCastle.san == "O-O-O#")
+    #expect(longCastle.lan == "e8c8")
   }
 
-  func testPromotionsNotation() {
+  @Test func promotionsNotation() {
     let pawn = Piece(.pawn, color: .white, square: .e8)
     let queen = Piece(.queen, color: .white, square: .e8)
     let rook = Piece(.rook, color: .white, square: .e8)
 
     var queenPromo = Move(result: .move, piece: pawn, start: .e7, end: .e8)
     queenPromo.promotedPiece = queen
-    XCTAssertEqual(queenPromo.san, "e8=Q")
-    XCTAssertEqual(queenPromo.lan, "e7e8q")
+    #expect(queenPromo.san == "e8=Q")
+    #expect(queenPromo.lan == "e7e8q")
 
     let capturedPiece = Piece(.bishop, color: .black, square: .f8)
     var rookCapturePromo = Move(result: .capture(capturedPiece), piece: pawn, start: .e7, end: .f8, checkState: .check)
     rookCapturePromo.promotedPiece = rook
-    XCTAssertEqual(rookCapturePromo.san, "exf8=R+")
-    XCTAssertEqual(rookCapturePromo.lan, "e7f8r")
+    #expect(rookCapturePromo.san == "exf8=R+")
+    #expect(rookCapturePromo.lan == "e7f8r")
   }
 
-  func testChecksNotation() {
+  @Test func checksNotation() {
     let check = Move(result: .move, piece: Piece(.queen, color: .white, square: .d4), start: .e3, end: .d4, checkState: .check)
-    XCTAssertEqual(check.san, "Qd4+")
-    XCTAssertEqual(check.lan, "e3d4")
+    #expect(check.san == "Qd4+")
+    #expect(check.lan == "e3d4")
   }
 
-  func testCheckmateNotation() {
+  @Test func checkmateNotation() {
     let checkmate = Move(result: .move, piece: Piece(.rook, color: .white, square: .g7), start: .g4, end: .g7, checkState: .checkmate)
-    XCTAssertEqual(checkmate.san, "Rg7#")
-    XCTAssertEqual(checkmate.lan, "g4g7")
+    #expect(checkmate.san == "Rg7#")
+    #expect(checkmate.lan == "g4g7")
   }
 
-  func testMoveAssessments() {
-    XCTAssertEqual(Move.Assessment.null.notation, "")
-    XCTAssertEqual(Move.Assessment.good.notation, "!")
-    XCTAssertEqual(Move.Assessment.mistake.notation, "?")
-    XCTAssertEqual(Move.Assessment.brilliant.notation, "!!")
-    XCTAssertEqual(Move.Assessment.blunder.notation, "??")
-    XCTAssertEqual(Move.Assessment.interesting.notation, "!?")
-    XCTAssertEqual(Move.Assessment.dubious.notation, "?!")
-    XCTAssertEqual(Move.Assessment.forced.notation, "□")
-    XCTAssertEqual(Move.Assessment.singular.notation, "")
-    XCTAssertEqual(Move.Assessment.worst.notation, "")
+  @Test func moveAssessments() {
+    #expect(Move.Assessment.null.notation == "")
+    #expect(Move.Assessment.good.notation == "!")
+    #expect(Move.Assessment.mistake.notation == "?")
+    #expect(Move.Assessment.brilliant.notation == "!!")
+    #expect(Move.Assessment.blunder.notation == "??")
+    #expect(Move.Assessment.interesting.notation == "!?")
+    #expect(Move.Assessment.dubious.notation == "?!")
+    #expect(Move.Assessment.forced.notation == "□")
+    #expect(Move.Assessment.singular.notation == "")
+    #expect(Move.Assessment.worst.notation == "")
   }
 
 }

--- a/Tests/ChessKitTests/MoveTreeTests.swift
+++ b/Tests/ChessKitTests/MoveTreeTests.swift
@@ -4,68 +4,68 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class MoveTreeTests: XCTestCase {
+struct MoveTreeTests {
 
-  func testEmptyCollection() {
+  @Test func emptyCollection() {
     let moveTree = MoveTree()
-    XCTAssertTrue(moveTree.isEmpty)
-    XCTAssertEqual(moveTree.startIndex, .minimum)
-    XCTAssertEqual(moveTree.endIndex, .minimum)
+    #expect(moveTree.isEmpty)
+    #expect(moveTree.startIndex == .minimum)
+    #expect(moveTree.endIndex == .minimum)
 
-    XCTAssertFalse(moveTree.hasIndex(before: .minimum))
-    XCTAssertFalse(moveTree.hasIndex(after: .minimum))
+    #expect(!moveTree.hasIndex(before: .minimum))
+    #expect(!moveTree.hasIndex(after: .minimum))
   }
 
-  func testSubscript() {
+  @Test func subscriptAccess() {
     var moveTree = MoveTree()
-    XCTAssertNil(moveTree[.minimum])
+    #expect(moveTree[.minimum] == nil)
 
     let e4 = Move(san: "e4", position: .standard)
     moveTree[.minimum.next] = e4
-    XCTAssertEqual(moveTree[.minimum.next], e4)
+    #expect(moveTree[.minimum.next] == e4)
   }
 
-  func testNodeHashValue() {
+  @Test func ndeHashValue() {
     var moveTree = MoveTree()
     let e4 = Move(san: "e4", position: .standard)
     moveTree[.minimum.next] = e4
-    XCTAssertNotNil(moveTree.dictionary[.minimum.next]?.hashValue)
+    #expect(moveTree.dictionary[.minimum.next]?.hashValue != nil)
   }
 
-  func testSameVariationComparability() {
+  @Test func sameVariationComparability() {
     let wIndex = MoveTree.Index(number: 4, color: .white, variation: 2)
-    XCTAssertLessThan(wIndex, wIndex.next)
-    XCTAssertGreaterThan(wIndex, wIndex.previous)
+    #expect(wIndex < wIndex.next)
+    #expect(wIndex > wIndex.previous)
 
     let bIndex = MoveTree.Index(number: 4, color: .black, variation: 2)
-    XCTAssertLessThan(bIndex, bIndex.next)
-    XCTAssertGreaterThan(bIndex, bIndex.previous)
+    #expect(bIndex < bIndex.next)
+    #expect(bIndex > bIndex.previous)
   }
 
-  func testDifferentVariationComparability() {
+  @Test func differentVariationComparability() {
     let wIndex1 = MoveTree.Index(number: 4, color: .white, variation: 2)
     let wIndex2 = MoveTree.Index(number: 4, color: .white, variation: 3)
-    XCTAssertGreaterThan(wIndex1, wIndex2)
-    XCTAssertGreaterThan(wIndex1.next, wIndex2.next)
-    XCTAssertGreaterThan(wIndex1.previous, wIndex2.next)
-    XCTAssertGreaterThan(wIndex1.next, wIndex2.previous)
-    XCTAssertGreaterThan(wIndex1.previous, wIndex2.previous)
+    #expect(wIndex1 > wIndex2)
+    #expect(wIndex1.next > wIndex2.next)
+    #expect(wIndex1.previous > wIndex2.next)
+    #expect(wIndex1.next > wIndex2.previous)
+    #expect(wIndex1.previous > wIndex2.previous)
 
     let bIndex1 = MoveTree.Index(number: 4, color: .black, variation: 2)
     let bIndex2 = MoveTree.Index(number: 4, color: .black, variation: 3)
-    XCTAssertGreaterThan(bIndex1, bIndex2)
-    XCTAssertGreaterThan(bIndex1.next, bIndex2.next)
-    XCTAssertGreaterThan(bIndex1.previous, bIndex2.next)
-    XCTAssertGreaterThan(bIndex1.next, bIndex2.previous)
-    XCTAssertGreaterThan(bIndex1.previous, bIndex2.previous)
+    #expect(bIndex1 > bIndex2)
+    #expect(bIndex1.next > bIndex2.next)
+    #expect(bIndex1.previous > bIndex2.next)
+    #expect(bIndex1.next > bIndex2.previous)
+    #expect(bIndex1.previous > bIndex2.previous)
   }
 
-  func testNonexistentIndexBeforeAndAfter() {
+  @Test func nonexistentIndexBeforeAndAfter() {
     let tree = MoveTree()
-    XCTAssertEqual(tree.index(after: .minimum), .minimum)
-    XCTAssertEqual(tree.index(before: .minimum), .minimum)
+    #expect(tree.index(after: .minimum) == .minimum)
+    #expect(tree.index(before: .minimum) == .minimum)
   }
 
 }
@@ -75,7 +75,7 @@ final class MoveTreeTests: XCTestCase {
 extension MoveTreeTests {
 
   @available(*, deprecated)
-  func testDeprecated() {
+  @Test func deprecated() {
     var moveTree = MoveTree()
 
     let move1 = Move(san: "e4", position: .standard)!
@@ -87,19 +87,19 @@ extension MoveTreeTests {
     moveTree.add(move: move1)
     moveTree.add(move: move2, toParentIndex: i1)
 
-    XCTAssertEqual(moveTree.previousIndex(for: i1), moveTree.index(before: i1))
-    XCTAssertEqual(moveTree.nextIndex(for: i1), moveTree.index(after: i1))
+    #expect(moveTree.previousIndex(for: i1) == moveTree.index(before: i1))
+    #expect(moveTree.nextIndex(for: i1) == moveTree.index(after: i1))
 
-    XCTAssertEqual(moveTree.move(at: i1), moveTree[i1])
-    XCTAssertEqual(moveTree.move(at: i1), move1)
+    #expect(moveTree.move(at: i1) == moveTree[i1])
+    #expect(moveTree.move(at: i1) == move1)
 
-    XCTAssertEqual(moveTree.move(at: i2), moveTree[i2])
-    XCTAssertEqual(moveTree.move(at: i2), move2)
+    #expect(moveTree.move(at: i2) == moveTree[i2])
+    #expect(moveTree.move(at: i2) == move2)
 
-    XCTAssertNil(moveTree.previousIndex(for: .minimum))
-    XCTAssertNil(moveTree.nextIndex(for: i2))
+    #expect(moveTree.previousIndex(for: .minimum) == nil)
+    #expect(moveTree.nextIndex(for: i2) == nil)
 
-    XCTAssertEqual(moveTree.nextIndex(for: .minimum), i1)
+    #expect(moveTree.nextIndex(for: .minimum) == i1)
   }
 
 }

--- a/Tests/ChessKitTests/Parsers/EngineLANParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/EngineLANParserTests.swift
@@ -4,63 +4,63 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class EngineLANParserTests: XCTestCase {
+struct EngineLANParserTests {
 
-  func testCapture() {
+  @Test func capture() {
     let position = Position(fen: "8/8/8/4p3/3P4/8/8/8 w - - 0 1")!
     let move = EngineLANParser.parse(move: "d4e5", for: .white, in: position)
 
     let capturedPiece = Piece(.pawn, color: .black, square: .e5)
-    XCTAssertEqual(move?.result, .capture(capturedPiece))
+    #expect(move?.result == .capture(capturedPiece))
   }
 
-  func testCastling() {
+  @Test func castling() {
     let p1 = Position(fen: "8/8/8/8/8/8/8/4K2R w KQ - 0 1")!
     let wShortCastle = EngineLANParser.parse(move: "e1g1", for: .white, in: p1)
-    XCTAssertEqual(wShortCastle?.result, .castle(.wK))
+    #expect(wShortCastle?.result == .castle(.wK))
 
     let p2 = Position(fen: "8/8/8/8/8/8/8/R3K3 w KQ - 0 1")!
     let wLongCastle = EngineLANParser.parse(move: "e1c1", for: .white, in: p2)
-    XCTAssertEqual(wLongCastle?.result, .castle(.wQ))
+    #expect(wLongCastle?.result == .castle(.wQ))
 
     let p3 = Position(fen: "4k2r/8/8/8/8/8/8/8 b kq - 0 1")!
     let bShortCastle = EngineLANParser.parse(move: "e8g8", for: .black, in: p3)
-    XCTAssertEqual(bShortCastle?.result, .castle(.bK))
+    #expect(bShortCastle?.result == .castle(.bK))
 
     let p4 = Position(fen: "r3k3/8/8/8/8/8/8/8 b kq - 0 1")!
     let bLongCastle = EngineLANParser.parse(move: "e8c8", for: .black, in: p4)
-    XCTAssertEqual(bLongCastle?.result, .castle(.bQ))
+    #expect(bLongCastle?.result == .castle(.bQ))
   }
 
-  func testPromotion() {
+  @Test func promotion() {
     let p = Position(fen: "8/P7/8/8/8/8/8/8 w - - 0 1")!
 
     let qPromotion = EngineLANParser.parse(move: "a7a8q", for: .white, in: p)
     let promotedQueen = Piece(.queen, color: .white, square: .a8)
-    XCTAssertEqual(qPromotion?.promotedPiece, promotedQueen)
+    #expect(qPromotion?.promotedPiece == promotedQueen)
 
     let rPromotion = EngineLANParser.parse(move: "a7a8r", for: .white, in: p)
     let promotedRook = Piece(.rook, color: .white, square: .a8)
-    XCTAssertEqual(rPromotion?.promotedPiece, promotedRook)
+    #expect(rPromotion?.promotedPiece == promotedRook)
 
     let bPromotion = EngineLANParser.parse(move: "a7a8b", for: .white, in: p)
     let promotedBishop = Piece(.bishop, color: .white, square: .a8)
-    XCTAssertEqual(bPromotion?.promotedPiece, promotedBishop)
+    #expect(bPromotion?.promotedPiece == promotedBishop)
 
     let nPromotion = EngineLANParser.parse(move: "a7a8n", for: .white, in: p)
     let promotedKnight = Piece(.knight, color: .white, square: .a8)
-    XCTAssertEqual(nPromotion?.promotedPiece, promotedKnight)
+    #expect(nPromotion?.promotedPiece == promotedKnight)
   }
 
-  func testValidLANButInvalidMove() {
-    XCTAssertNil(EngineLANParser.parse(move: "a4b5", for: .white, in: .standard))
-    XCTAssertNil(EngineLANParser.parse(move: "f8b5", for: .black, in: .standard))
+  @Test func validLANButInvalidMove() {
+    #expect(EngineLANParser.parse(move: "a4b5", for: .white, in: .standard) == nil)
+    #expect(EngineLANParser.parse(move: "f8b5", for: .black, in: .standard) == nil)
   }
 
-  func testInvalidLAN() {
-    XCTAssertNil(EngineLANParser.parse(move: "bad move", for: .white, in: .standard))
+  @Test func invalidLAN() {
+    #expect(EngineLANParser.parse(move: "bad move", for: .white, in: .standard) == nil)
   }
 
 }

--- a/Tests/ChessKitTests/Parsers/FENParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/FENParserTests.swift
@@ -4,93 +4,93 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class FENParserTests: XCTestCase {
+struct FENParserTests {
 
-  func testStandardStartingPosition() {
+  @Test func standardStartingPosition() {
     let p = Position.standard
 
-    XCTAssertEqual(p.pieces.count, 32)
-    XCTAssertEqual(p.sideToMove, .white)
-    XCTAssertEqual(p.legalCastlings, LegalCastlings(legal: [.bK, .wK, .bQ, .wQ]))
-    XCTAssertNil(p.enPassant)
-    XCTAssertEqual(p.clock.halfmoves, 0)
-    XCTAssertEqual(p.clock.fullmoves, 1)
+    #expect(p.pieces.count == 32)
+    #expect(p.sideToMove == .white)
+    #expect(p.legalCastlings == LegalCastlings(legal: [.bK, .wK, .bQ, .wQ]))
+    #expect(p.enPassant == nil)
+    #expect(p.clock.halfmoves == 0)
+    #expect(p.clock.fullmoves == 1)
   }
 
-  func testComplexPiecePlacement() {
+  @Test func complexPiecePlacement() {
     let p = Position.complex
 
-    XCTAssertEqual(p.pieces.count, 24)
-    XCTAssertEqual(p.sideToMove, .black)
-    XCTAssertEqual(p.legalCastlings, LegalCastlings(legal: [.bK, .bQ]))
-    XCTAssertNil(p.enPassant)
-    XCTAssertEqual(p.clock.halfmoves, 0)
-    XCTAssertEqual(p.clock.fullmoves, 20)
+    #expect(p.pieces.count == 24)
+    #expect(p.sideToMove == .black)
+    #expect(p.legalCastlings == LegalCastlings(legal: [.bK, .bQ]))
+    #expect(p.enPassant == nil)
+    #expect(p.clock.halfmoves == 0)
+    #expect(p.clock.fullmoves == 20)
 
     // pieces
-    XCTAssertTrue(p.pieces.contains(Piece(.rook, color: .black, square: .a8)))
-    XCTAssertTrue(p.pieces.contains(Piece(.bishop, color: .black, square: .c8)))
-    XCTAssertTrue(p.pieces.contains(Piece(.king, color: .black, square: .e8)))
-    XCTAssertTrue(p.pieces.contains(Piece(.knight, color: .black, square: .g8)))
-    XCTAssertTrue(p.pieces.contains(Piece(.rook, color: .black, square: .h8)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .black, square: .a7)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .black, square: .d7)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .black, square: .f7)))
-    XCTAssertTrue(p.pieces.contains(Piece(.knight, color: .white, square: .g7)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .black, square: .h7)))
-    XCTAssertTrue(p.pieces.contains(Piece(.knight, color: .black, square: .a6)))
-    XCTAssertTrue(p.pieces.contains(Piece(.bishop, color: .white, square: .d6)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .black, square: .b5)))
-    XCTAssertTrue(p.pieces.contains(Piece(.knight, color: .white, square: .d5)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .white, square: .e5)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .white, square: .h5)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .white, square: .g4)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .white, square: .d3)))
-    XCTAssertTrue(p.pieces.contains(Piece(.queen, color: .white, square: .f3)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .white, square: .a2)))
-    XCTAssertTrue(p.pieces.contains(Piece(.pawn, color: .white, square: .c2)))
-    XCTAssertTrue(p.pieces.contains(Piece(.king, color: .white, square: .e2)))
-    XCTAssertTrue(p.pieces.contains(Piece(.queen, color: .black, square: .a1)))
-    XCTAssertTrue(p.pieces.contains(Piece(.bishop, color: .black, square: .g1)))
+    #expect(p.pieces.contains(Piece(.rook, color: .black, square: .a8)))
+    #expect(p.pieces.contains(Piece(.bishop, color: .black, square: .c8)))
+    #expect(p.pieces.contains(Piece(.king, color: .black, square: .e8)))
+    #expect(p.pieces.contains(Piece(.knight, color: .black, square: .g8)))
+    #expect(p.pieces.contains(Piece(.rook, color: .black, square: .h8)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .black, square: .a7)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .black, square: .d7)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .black, square: .f7)))
+    #expect(p.pieces.contains(Piece(.knight, color: .white, square: .g7)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .black, square: .h7)))
+    #expect(p.pieces.contains(Piece(.knight, color: .black, square: .a6)))
+    #expect(p.pieces.contains(Piece(.bishop, color: .white, square: .d6)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .black, square: .b5)))
+    #expect(p.pieces.contains(Piece(.knight, color: .white, square: .d5)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .white, square: .e5)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .white, square: .h5)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .white, square: .g4)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .white, square: .d3)))
+    #expect(p.pieces.contains(Piece(.queen, color: .white, square: .f3)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .white, square: .a2)))
+    #expect(p.pieces.contains(Piece(.pawn, color: .white, square: .c2)))
+    #expect(p.pieces.contains(Piece(.king, color: .white, square: .e2)))
+    #expect(p.pieces.contains(Piece(.queen, color: .black, square: .a1)))
+    #expect(p.pieces.contains(Piece(.bishop, color: .black, square: .g1)))
   }
 
-  func testEnPassantPosition() {
+  @Test func enPassantPosition() {
     let whiteEP = Position(fen: "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1")!
 
-    XCTAssertEqual(whiteEP.sideToMove, .black)
-    XCTAssertEqual(whiteEP.enPassant, EnPassant(pawn: Piece(.pawn, color: .white, square: .e4)))
+    #expect(whiteEP.sideToMove == .black)
+    #expect(whiteEP.enPassant == EnPassant(pawn: Piece(.pawn, color: .white, square: .e4)))
 
     let blackEP = Position(fen: "rnbqkbnr/pppppppp/8/4P3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq e6 0 2")!
 
-    XCTAssertEqual(blackEP.sideToMove, .white)
-    XCTAssertEqual(blackEP.enPassant, EnPassant(pawn: Piece(.pawn, color: .black, square: .e5)))
+    #expect(blackEP.sideToMove == .white)
+    #expect(blackEP.enPassant == EnPassant(pawn: Piece(.pawn, color: .black, square: .e5)))
   }
 
-  func testInvalidFen() {
+  @Test func invalidFen() {
     let p = Position(fen: "invalid")
-    XCTAssertNil(p)
+    #expect(p == nil)
 
     let invalidSideToMove = Position(fen: "8/8/8/4p1K1/2k1P3/8/8/8 B - - 0 1")!
-    XCTAssertEqual(invalidSideToMove.sideToMove, .white)
+    #expect(invalidSideToMove.sideToMove == .white)
   }
 
-  func testConvertPosition() {
+  @Test func convertPosition() {
     let standardFen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
-    XCTAssertEqual(Position.standard.fen, standardFen)
+    #expect(Position.standard.fen == standardFen)
 
     let complexFen = "r1b1k1nr/p2p1pNp/n2B4/1p1NP2P/6P1/3P1Q2/P1P1K3/q5b1 b kq - 0 20"
-    XCTAssertEqual(Position.complex.fen, complexFen)
+    #expect(Position.complex.fen == complexFen)
 
     let epFen = "rnbqkbnr/ppppp1pp/8/8/4Pp2/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
-    XCTAssertEqual(Position.ep.fen, epFen)
+    #expect(Position.ep.fen == epFen)
 
     let castlingFen = "4k2r/6r1/8/8/8/8/3R4/R3K3 w Qk - 0 1"
-    XCTAssertEqual(Position.castling.fen, castlingFen)
+    #expect(Position.castling.fen == castlingFen)
 
     let fiftyMoveFen = "8/5k2/3p4/1p1Pp2p/pP2Pp1P/P4P1K/8/8 b - - 99 50"
-    XCTAssertEqual(Position.fiftyMove.fen, fiftyMoveFen)
+    #expect(Position.fiftyMove.fen == fiftyMoveFen)
   }
 
 }

--- a/Tests/ChessKitTests/Parsers/PGNParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/PGNParserTests.swift
@@ -4,123 +4,83 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class PGNParserTests: XCTestCase {
+struct PGNParserTests {
 
-  func testGameFromPGN() {
+  @Test func gameFromPGN() {
     let game = PGNParser.parse(game: Game.fischerSpassky)
     let gameFromPGN = Game(pgn: Game.fischerSpassky)
 
-    XCTAssertEqual(game, gameFromPGN)
+    #expect(game == gameFromPGN)
   }
 
-  func testTagParsing() {
+  @Test func tagParsing() {
     let game = PGNParser.parse(game: Game.fischerSpassky)
 
     // tags
-    XCTAssertEqual(game.tags.event, "F/S Return Match")
-    XCTAssertEqual(game.tags.site, "Belgrade, Serbia JUG")
-    XCTAssertEqual(game.tags.date, "1992.11.04")
-    XCTAssertEqual(game.tags.round, "29")
-    XCTAssertEqual(game.tags.white, "Fischer, Robert J.")
-    XCTAssertEqual(game.tags.black, "Spassky, Boris V.")
-    XCTAssertEqual(game.tags.result, "1/2-1/2")
+    #expect(game.tags.event == "F/S Return Match")
+    #expect(game.tags.site == "Belgrade, Serbia JUG")
+    #expect(game.tags.date == "1992.11.04")
+    #expect(game.tags.round == "29")
+    #expect(game.tags.white == "Fischer, Robert J.")
+    #expect(game.tags.black == "Spassky, Boris V.")
+    #expect(game.tags.result == "1/2-1/2")
   }
 
-  func testCustomTagParsing() {
+  @Test func customTagParsing() {
     // invalid pair
     let g1 = PGNParser.parse(game: "[a] 1. e4 e5")
-    XCTAssertNil(g1.tags.other["a"])
+    #expect(g1.tags.other["a"] == nil)
 
     // custom tag
     let g2 = PGNParser.parse(game: "[CustomTag \"Value\"] 1. e4 e5")
-    XCTAssertEqual(g2.tags.other["CustomTag"], "Value")
+    #expect(g2.tags.other["CustomTag"] == "Value")
 
     // duplicate tags
     let g3 = PGNParser.parse(game: "[CustomTag \"Value\"] [CustomTag \"Value2\"] 1. e4 e5")
-    XCTAssertEqual(g3.tags.other["CustomTag"], "Value")
+    #expect(g3.tags.other["CustomTag"] == "Value")
   }
 
-  func testValidResultParsing() {
+  @Test func validResultParsing() {
     let g1 = PGNParser.parse(game: "1. e4 e5 1/2-1/2")
-    XCTAssertEqual(g1.tags.result, "1/2-1/2")
+    #expect(g1.tags.result == "1/2-1/2")
 
     let g2 = PGNParser.parse(game: "1. e4 e5 1-0")
-    XCTAssertEqual(g2.tags.result, "1-0")
+    #expect(g2.tags.result == "1-0")
 
     let g3 = PGNParser.parse(game: "1. e4 e5 0-1")
-    XCTAssertEqual(g3.tags.result, "0-1")
+    #expect(g3.tags.result == "0-1")
 
     let g4 = PGNParser.parse(game: "1. e4 e5 *")
-    XCTAssertEqual(g4.tags.result, "*")
+    #expect(g4.tags.result == "*")
   }
 
-  func testInvalidResultParsing() {
+  @Test func invalidResultParsing() {
     let g1 = PGNParser.parse(game: "1. e4 e5 ***")
-    XCTAssertEqual(g1.tags.result, "")
+    #expect(g1.tags.result == "")
 
     let g2 = PGNParser.parse(game: "1. e4 e5 test")
-    XCTAssertEqual(g2.tags.result, "")
+    #expect(g2.tags.result == "")
 
     let g3 = PGNParser.parse(game: "1. e4 e5 1-00-1")
-    XCTAssertEqual(g3.tags.result, "")
+    #expect(g3.tags.result == "")
   }
 
-  func testMoveTextParsing() {
+  @Test func moveTextParsing() {
     let game = PGNParser.parse(game: Game.fischerSpassky)
 
     // starting position + 85 ply
-    XCTAssertEqual(game.positions.keys.count, 86)
+    #expect(game.positions.keys.count == 86)
 
-    XCTAssertEqual(
-      game.moves[
-        .init(
-          number: 1,
-          color: .white
-        )]?.assessment, .blunder)
-    XCTAssertEqual(
-      game.moves[
-        .init(
-          number: 1,
-          color: .black
-        )]?.assessment, .brilliant)
-    XCTAssertEqual(
-      game.moves[
-        .init(
-          number: 3,
-          color: .black
-        )]?.comment, "This opening is called the Ruy Lopez.")
-    XCTAssertEqual(
-      game.moves[
-        .init(
-          number: 4,
-          color: .white
-        )]?.comment, "test comment")
-    XCTAssertEqual(
-      game.moves[
-        .init(
-          number: 10,
-          color: .white
-        )]?.end, .d4)
-    XCTAssertEqual(
-      game.moves[
-        .init(
-          number: 18,
-          color: .black
-        )]?.piece.kind, .queen)
-    XCTAssertEqual(
-      game.moves[
-        .init(
-          number: 18,
-          color: .black
-        )]?.end, .e7)
-    XCTAssertEqual(
-      game.moves[
-        .init(
-          number: 36,
-          color: .white
-        )]?.checkState, .check)
+    #expect(game.moves[.init(number: 1, color: .white)]?.assessment == .blunder)
+    #expect(game.moves[.init(number: 1, color: .black)]?.assessment == .brilliant)
+    #expect(game.moves[.init(number: 3, color: .black)]?.comment == "This opening is called the Ruy Lopez.")
+    #expect(game.moves[.init(number: 4, color: .white)]?.comment == "test comment")
+    #expect(game.moves[.init(number: 10, color: .white)]?.end == .d4)
+    #expect(game.moves[.init(number: 18, color: .black)]?.piece.kind == .queen)
+    #expect(game.moves[.init(number: 18, color: .black)]?.end == .e7)
+    #expect(game.moves[.init(number: 36, color: .white)]?.checkState == .check)
   }
 
 }

--- a/Tests/ChessKitTests/Parsers/SANParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/SANParserTests.swift
@@ -4,84 +4,84 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class SANParserTests: XCTestCase {
+struct SANParserTests {
 
-  func testCastling() {
+  @Test func castling() {
     let p1 = Position(fen: "r3k3/8/8/8/8/8/8/4K2R w Kq - 0 1")!
     let shortCastle = SANParser.parse(move: "O-O", in: p1)
-    XCTAssertEqual(shortCastle?.result, .castle(.wK))
+    #expect(shortCastle?.result == .castle(.wK))
 
     let p2 = Position(fen: "r3k3/8/8/8/8/8/8/5RK1 b q - 0 1")!
     let longCastle = SANParser.parse(move: "O-O-O", in: p2)
-    XCTAssertEqual(longCastle?.result, .castle(.bQ))
+    #expect(longCastle?.result == .castle(.bQ))
   }
 
-  func testPromotion() {
+  @Test func promotion() {
     let p = Position(fen: "8/P7/8/8/8/8/8/8 w - - 0 1")!
     let promotion = SANParser.parse(move: "a8=Q", in: p)
 
     let promotedPiece = Piece(.queen, color: .white, square: .a8)
-    XCTAssertEqual(promotion?.promotedPiece, promotedPiece)
+    #expect(promotion?.promotedPiece == promotedPiece)
   }
 
-  func testChecksAndMates() {
+  @Test func checksAndMates() {
     let p1 = Position(fen: "8/k7/7Q/6R1/8/8/8/8 w - - 0 1")!
 
     let check = SANParser.parse(move: "Rg7+", in: p1)
-    XCTAssertEqual(check?.checkState, .check)
+    #expect(check?.checkState == .check)
 
     let p2 = Position(fen: "8/k5R1/7Q/8/8/8/8/8 b - - 0 1")!
 
     let kingMove = SANParser.parse(move: "Ka8", in: p2)
-    XCTAssertEqual(kingMove?.checkState, Move.CheckState.none)
+    #expect(kingMove?.checkState == Move.CheckState.none)
 
     let p3 = Position(fen: "k7/6R1/7Q/8/8/8/8/8 w - - 0 1")!
 
     let checkmate = SANParser.parse(move: "Qh8#", in: p3)
-    XCTAssertEqual(checkmate?.checkState, .checkmate)
+    #expect(checkmate?.checkState == .checkmate)
   }
 
-  func testDisambiguation() {
+  @Test func disambiguation() {
     let pw = Position(fen: "3r3r/8/8/R7/4Q2Q/8/8/R6Q w - - 0 1")!
     let pb = Position(fen: "3r3r/8/8/R7/4Q2Q/8/8/R6Q b - - 0 1")!
 
     let rookFileMove = SANParser.parse(move: "R1a3", in: pw)
-    XCTAssertEqual(rookFileMove?.result, .move)
-    XCTAssertEqual(rookFileMove?.piece.kind, .rook)
-    XCTAssertEqual(rookFileMove?.disambiguation, .byRank(1))
-    XCTAssertEqual(rookFileMove?.start, .a1)
-    XCTAssertEqual(rookFileMove?.end, .a3)
-    XCTAssertEqual(rookFileMove?.promotedPiece, nil)
-    XCTAssertEqual(rookFileMove?.checkState, Move.CheckState.none)
+    #expect(rookFileMove?.result == .move)
+    #expect(rookFileMove?.piece.kind == .rook)
+    #expect(rookFileMove?.disambiguation == .byRank(1))
+    #expect(rookFileMove?.start == .a1)
+    #expect(rookFileMove?.end == .a3)
+    #expect(rookFileMove?.promotedPiece == nil)
+    #expect(rookFileMove?.checkState == Move.CheckState.none)
 
     let rookRankMove = SANParser.parse(move: "Rdf8", in: pb)
-    XCTAssertEqual(rookRankMove?.result, .move)
-    XCTAssertEqual(rookRankMove?.piece.kind, .rook)
-    XCTAssertEqual(rookRankMove?.disambiguation, .byFile(.d))
-    XCTAssertEqual(rookRankMove?.start, .d8)
-    XCTAssertEqual(rookRankMove?.end, .f8)
-    XCTAssertEqual(rookRankMove?.promotedPiece, nil)
-    XCTAssertEqual(rookRankMove?.checkState, Move.CheckState.none)
+    #expect(rookRankMove?.result == .move)
+    #expect(rookRankMove?.piece.kind == .rook)
+    #expect(rookRankMove?.disambiguation == .byFile(.d))
+    #expect(rookRankMove?.start == .d8)
+    #expect(rookRankMove?.end == .f8)
+    #expect(rookRankMove?.promotedPiece == nil)
+    #expect(rookRankMove?.checkState == Move.CheckState.none)
 
     let queenMove = SANParser.parse(move: "Qh4e1", in: pw)
-    XCTAssertEqual(queenMove?.result, .move)
-    XCTAssertEqual(queenMove?.piece.kind, .queen)
-    XCTAssertEqual(queenMove?.disambiguation, .bySquare(.h4))
-    XCTAssertEqual(queenMove?.start, .h4)
-    XCTAssertEqual(queenMove?.end, .e1)
-    XCTAssertEqual(queenMove?.promotedPiece, nil)
-    XCTAssertEqual(queenMove?.checkState, Move.CheckState.none)
+    #expect(queenMove?.result == .move)
+    #expect(queenMove?.piece.kind == .queen)
+    #expect(queenMove?.disambiguation == .bySquare(.h4))
+    #expect(queenMove?.start == .h4)
+    #expect(queenMove?.end == .e1)
+    #expect(queenMove?.promotedPiece == nil)
+    #expect(queenMove?.checkState == Move.CheckState.none)
   }
 
-  func testValidSANButInvalidMove() {
-    XCTAssertNil(SANParser.parse(move: "axb5", in: .standard))
-    XCTAssertNil(SANParser.parse(move: "Bb5", in: .standard))
+  @Test func testValidSANButInvalidMove() {
+    #expect(SANParser.parse(move: "axb5", in: .standard) == nil)
+    #expect(SANParser.parse(move: "Bb5", in: .standard) == nil)
   }
 
-  func testInvalidSAN() {
-    XCTAssertNil(SANParser.parse(move: "bad move", in: .standard))
+  @Test func invalidSAN() {
+    #expect(SANParser.parse(move: "bad move", in: .standard) == nil)
   }
 
 }

--- a/Tests/ChessKitTests/Performance/PGNParserPerformanceTests.swift
+++ b/Tests/ChessKitTests/Performance/PGNParserPerformanceTests.swift
@@ -9,6 +9,12 @@ import XCTest
 final class PGNParserPerformanceTests: XCTestCase {
 
   func testBoardPerformance() {
+    // Clock Monotonic Time: 0.011 s
+    // CPU Cycles: 32097.649 kC
+    // CPU Instructions Retired: 107155.368 kI
+    // CPU Time: 0.010 s
+    // Memory Peak Physical: 34026.138 kB
+    // Memory Physical: 160.563 kB
     measure(
       metrics: [
         XCTClockMetric(),

--- a/Tests/ChessKitTests/PieceTests.swift
+++ b/Tests/ChessKitTests/PieceTests.swift
@@ -4,107 +4,115 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class PieceTests: XCTestCase {
+struct PieceTests {
 
-  func testNotation() {
+  @Test func notation() {
     let pawn = Piece.Kind.pawn
-    XCTAssertEqual(pawn.notation, "")
+    #expect(pawn.notation == "")
+    #expect(String(describing: pawn) == "Pawn")
 
     let bishop = Piece.Kind.bishop
-    XCTAssertEqual(bishop.notation, "B")
+    #expect(bishop.notation == "B")
+    #expect(String(describing: bishop) == "Bishop")
 
     let knight = Piece.Kind.knight
-    XCTAssertEqual(knight.notation, "N")
+    #expect(knight.notation == "N")
+    #expect(String(describing: knight) == "Knight")
 
     let rook = Piece.Kind.rook
-    XCTAssertEqual(rook.notation, "R")
+    #expect(rook.notation == "R")
+    #expect(String(describing: rook) == "Rook")
 
     let queen = Piece.Kind.queen
-    XCTAssertEqual(queen.notation, "Q")
+    #expect(queen.notation == "Q")
+    #expect(String(describing: queen) == "Queen")
 
     let king = Piece.Kind.king
-    XCTAssertEqual(king.notation, "K")
+    #expect(king.notation == "K")
+    #expect(String(describing: king) == "King")
   }
 
-  func testPieceColor() {
+  @Test func pieceColor() {
     let white = Piece.Color.white
-    XCTAssertEqual(white.rawValue, "w")
-    XCTAssertEqual(white.opposite, .black)
+    #expect(white.rawValue == "w")
+    #expect(white.opposite == .black)
+    #expect(String(describing: white) == "White")
 
     let black = Piece.Color.black
-    XCTAssertEqual(black.rawValue, "b")
-    XCTAssertEqual(black.opposite, .white)
+    #expect(black.rawValue == "b")
+    #expect(black.opposite == .white)
+    #expect(String(describing: black) == "Black")
   }
 
-  func testFenRepresentation() {
+  @Test func fenRepresentation() {
     let sq = Square.a1
 
     let wP = Piece(fen: "P", square: sq)
-    XCTAssertEqual(wP?.color, .white)
-    XCTAssertEqual(wP?.kind, .pawn)
-    XCTAssertEqual(wP?.square, sq)
+    #expect(wP?.color == .white)
+    #expect(wP?.kind == .pawn)
+    #expect(wP?.square == sq)
 
     let wB = Piece(fen: "B", square: sq)
-    XCTAssertEqual(wB?.color, .white)
-    XCTAssertEqual(wB?.kind, .bishop)
-    XCTAssertEqual(wB?.square, sq)
+    #expect(wB?.color == .white)
+    #expect(wB?.kind == .bishop)
+    #expect(wB?.square == sq)
 
     let wN = Piece(fen: "N", square: sq)
-    XCTAssertEqual(wN?.color, .white)
-    XCTAssertEqual(wN?.kind, .knight)
-    XCTAssertEqual(wN?.square, sq)
+    #expect(wN?.color == .white)
+    #expect(wN?.kind == .knight)
+    #expect(wN?.square == sq)
 
     let wR = Piece(fen: "R", square: sq)
-    XCTAssertEqual(wR?.color, .white)
-    XCTAssertEqual(wR?.kind, .rook)
-    XCTAssertEqual(wR?.square, sq)
+    #expect(wR?.color == .white)
+    #expect(wR?.kind == .rook)
+    #expect(wR?.square == sq)
 
     let wQ = Piece(fen: "Q", square: sq)
-    XCTAssertEqual(wQ?.color, .white)
-    XCTAssertEqual(wQ?.kind, .queen)
-    XCTAssertEqual(wQ?.square, sq)
+    #expect(wQ?.color == .white)
+    #expect(wQ?.kind == .queen)
+    #expect(wQ?.square == sq)
 
     let wK = Piece(fen: "K", square: sq)
-    XCTAssertEqual(wK?.color, .white)
-    XCTAssertEqual(wK?.kind, .king)
-    XCTAssertEqual(wK?.square, sq)
+    #expect(wK?.color == .white)
+    #expect(wK?.kind == .king)
+    #expect(wK?.square == sq)
 
     let bP = Piece(fen: "p", square: sq)
-    XCTAssertEqual(bP?.color, .black)
-    XCTAssertEqual(bP?.kind, .pawn)
-    XCTAssertEqual(bP?.square, sq)
+    #expect(bP?.color == .black)
+    #expect(bP?.kind == .pawn)
+    #expect(bP?.square == sq)
 
     let bB = Piece(fen: "b", square: sq)
-    XCTAssertEqual(bB?.color, .black)
-    XCTAssertEqual(bB?.kind, .bishop)
-    XCTAssertEqual(bB?.square, sq)
+    #expect(bB?.color == .black)
+    #expect(bB?.kind == .bishop)
+    #expect(bB?.square == sq)
 
     let bN = Piece(fen: "n", square: sq)
-    XCTAssertEqual(bN?.color, .black)
-    XCTAssertEqual(bN?.kind, .knight)
-    XCTAssertEqual(bN?.square, sq)
+    #expect(bN?.color == .black)
+    #expect(bN?.kind == .knight)
+    #expect(bN?.square == sq)
 
     let bR = Piece(fen: "r", square: sq)
-    XCTAssertEqual(bR?.color, .black)
-    XCTAssertEqual(bR?.kind, .rook)
-    XCTAssertEqual(bR?.square, sq)
+    #expect(bR?.color == .black)
+    #expect(bR?.kind == .rook)
+    #expect(bR?.square == sq)
 
     let bQ = Piece(fen: "q", square: sq)
-    XCTAssertEqual(bQ?.color, .black)
-    XCTAssertEqual(bQ?.kind, .queen)
-    XCTAssertEqual(bQ?.square, sq)
+    #expect(bQ?.color == .black)
+    #expect(bQ?.kind == .queen)
+    #expect(bQ?.square == sq)
 
     let bK = Piece(fen: "k", square: sq)
-    XCTAssertEqual(bK?.color, .black)
-    XCTAssertEqual(bK?.kind, .king)
-    XCTAssertEqual(bK?.square, sq)
+    #expect(bK?.color == .black)
+    #expect(bK?.kind == .king)
+    #expect(bK?.square == sq)
   }
 
-  func testInvalidFenRepresentation() {
+  @Test func invalidFenRepresentation() {
     let invalidFen = Piece(fen: "invalid", square: .a1)
-    XCTAssertNil(invalidFen)
+    #expect(invalidFen == nil)
   }
 
 }

--- a/Tests/ChessKitTests/SpecialMoveTests.swift
+++ b/Tests/ChessKitTests/SpecialMoveTests.swift
@@ -4,29 +4,29 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class SpecialMoveTests: XCTestCase {
+struct SpecialMoveTests {
 
-  func testLegalCastlingInvalidationForKings() {
+  @Test func legalCastlingInvalidationForKings() {
     let blackKing = Piece(.king, color: .black, square: .e8)
     let whiteKing = Piece(.king, color: .white, square: .e1)
 
     var legalCastlings = LegalCastlings()
     legalCastlings.invalidateCastling(for: blackKing)
-    XCTAssertFalse(legalCastlings.contains(.bK))
-    XCTAssertFalse(legalCastlings.contains(.bQ))
-    XCTAssertTrue(legalCastlings.contains(.wK))
-    XCTAssertTrue(legalCastlings.contains(.wQ))
+    #expect(!legalCastlings.contains(.bK))
+    #expect(!legalCastlings.contains(.bQ))
+    #expect(legalCastlings.contains(.wK))
+    #expect(legalCastlings.contains(.wQ))
 
     legalCastlings.invalidateCastling(for: whiteKing)
-    XCTAssertFalse(legalCastlings.contains(.bK))
-    XCTAssertFalse(legalCastlings.contains(.bQ))
-    XCTAssertFalse(legalCastlings.contains(.wK))
-    XCTAssertFalse(legalCastlings.contains(.wQ))
+    #expect(!legalCastlings.contains(.bK))
+    #expect(!legalCastlings.contains(.bQ))
+    #expect(!legalCastlings.contains(.wK))
+    #expect(!legalCastlings.contains(.wQ))
   }
 
-  func testLegalCastlingInvalidationForRooks() {
+  @Test func legalCastlingInvalidationForRooks() {
     let blackKingsideRook = Piece(.rook, color: .black, square: .h8)
     let blackQueensideRook = Piece(.rook, color: .black, square: .a8)
     let whiteKingsideRook = Piece(.rook, color: .white, square: .h1)
@@ -34,50 +34,50 @@ final class SpecialMoveTests: XCTestCase {
 
     var legalCastlings = LegalCastlings()
     legalCastlings.invalidateCastling(for: blackKingsideRook)
-    XCTAssertFalse(legalCastlings.contains(.bK))
-    XCTAssertTrue(legalCastlings.contains(.bQ))
-    XCTAssertTrue(legalCastlings.contains(.wK))
-    XCTAssertTrue(legalCastlings.contains(.wQ))
+    #expect(!legalCastlings.contains(.bK))
+    #expect(legalCastlings.contains(.bQ))
+    #expect(legalCastlings.contains(.wK))
+    #expect(legalCastlings.contains(.wQ))
 
     legalCastlings.invalidateCastling(for: blackQueensideRook)
-    XCTAssertFalse(legalCastlings.contains(.bK))
-    XCTAssertFalse(legalCastlings.contains(.bQ))
-    XCTAssertTrue(legalCastlings.contains(.wK))
-    XCTAssertTrue(legalCastlings.contains(.wQ))
+    #expect(!legalCastlings.contains(.bK))
+    #expect(!legalCastlings.contains(.bQ))
+    #expect(legalCastlings.contains(.wK))
+    #expect(legalCastlings.contains(.wQ))
 
     legalCastlings.invalidateCastling(for: whiteKingsideRook)
-    XCTAssertFalse(legalCastlings.contains(.bK))
-    XCTAssertFalse(legalCastlings.contains(.bQ))
-    XCTAssertFalse(legalCastlings.contains(.wK))
-    XCTAssertTrue(legalCastlings.contains(.wQ))
+    #expect(!legalCastlings.contains(.bK))
+    #expect(!legalCastlings.contains(.bQ))
+    #expect(!legalCastlings.contains(.wK))
+    #expect(legalCastlings.contains(.wQ))
 
     legalCastlings.invalidateCastling(for: whiteQueensideRook)
-    XCTAssertFalse(legalCastlings.contains(.bK))
-    XCTAssertFalse(legalCastlings.contains(.bQ))
-    XCTAssertFalse(legalCastlings.contains(.wK))
-    XCTAssertFalse(legalCastlings.contains(.wQ))
+    #expect(!legalCastlings.contains(.bK))
+    #expect(!legalCastlings.contains(.bQ))
+    #expect(!legalCastlings.contains(.wK))
+    #expect(!legalCastlings.contains(.wQ))
   }
 
-  func testEnPassantCaptureSquare() {
+  @Test func enPassantCaptureSquare() {
     let blackPawn = Piece(.pawn, color: .black, square: .d5)
     let blackEnPassant = EnPassant(pawn: blackPawn)
-    XCTAssertEqual(blackEnPassant.captureSquare, Square.d6)
-    XCTAssertTrue(blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .e5)))
-    XCTAssertTrue(blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .c5)))
-    XCTAssertFalse(blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .e5)))
-    XCTAssertFalse(blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .f5)))
-    XCTAssertFalse(blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .b5)))
-    XCTAssertFalse(blackEnPassant.couldBeCaptured(by: Piece(.bishop, color: .white, square: .c5)))
+    #expect(blackEnPassant.captureSquare == Square.d6)
+    #expect(blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .e5)))
+    #expect(blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .c5)))
+    #expect(!blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .e5)))
+    #expect(!blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .f5)))
+    #expect(!blackEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .b5)))
+    #expect(!blackEnPassant.couldBeCaptured(by: Piece(.bishop, color: .white, square: .c5)))
 
     let whitePawn = Piece(.pawn, color: .white, square: .d4)
     let whiteEnPassant = EnPassant(pawn: whitePawn)
-    XCTAssertEqual(whiteEnPassant.captureSquare, Square.d3)
-    XCTAssertTrue(whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .e4)))
-    XCTAssertTrue(whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .c4)))
-    XCTAssertFalse(whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .e4)))
-    XCTAssertFalse(whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .f4)))
-    XCTAssertFalse(whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .b4)))
-    XCTAssertFalse(whiteEnPassant.couldBeCaptured(by: Piece(.bishop, color: .black, square: .c4)))
+    #expect(whiteEnPassant.captureSquare == Square.d3)
+    #expect(whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .e4)))
+    #expect(whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .c4)))
+    #expect(!whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .white, square: .e4)))
+    #expect(!whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .f4)))
+    #expect(!whiteEnPassant.couldBeCaptured(by: Piece(.pawn, color: .black, square: .b4)))
+    #expect(!whiteEnPassant.couldBeCaptured(by: Piece(.bishop, color: .black, square: .c4)))
   }
 
 }

--- a/Tests/ChessKitTests/SquareTests.swift
+++ b/Tests/ChessKitTests/SquareTests.swift
@@ -4,68 +4,68 @@
 //
 
 @testable import ChessKit
-import XCTest
+import Testing
 
-final class SquareTests: XCTestCase {
+struct SquareTests {
 
-  func testNotation() {
-    XCTAssertEqual(Square.a1.notation, "a1")
-    XCTAssertEqual(Square.h1.notation, "h1")
-    XCTAssertEqual(Square.a8.notation, "a8")
-    XCTAssertEqual(Square.h8.notation, "h8")
+  @Test func notation() {
+    #expect(Square.a1.notation == "a1")
+    #expect(Square.h1.notation == "h1")
+    #expect(Square.a8.notation == "a8")
+    #expect(Square.h8.notation == "h8")
 
-    XCTAssertEqual(Square("a1"), .a1)
-    XCTAssertEqual(Square("h1"), .h1)
-    XCTAssertEqual(Square("a8"), .a8)
-    XCTAssertEqual(Square("h8"), .h8)
+    #expect(Square("a1") == .a1)
+    #expect(Square("h1") == .h1)
+    #expect(Square("a8") == .a8)
+    #expect(Square("h8") == .h8)
   }
 
-  func testInvalidNotation() {
-    XCTAssertEqual(Square("invalid"), .a1)
+  @Test func invalidNotation() {
+    #expect(Square("invalid") == .a1)
   }
 
-  func testSquareColor() {
-    XCTAssertEqual(Square.a1.color, .dark)
-    XCTAssertEqual(Square.h1.color, .light)
-    XCTAssertEqual(Square.a8.color, .light)
-    XCTAssertEqual(Square.h8.color, .dark)
+  @Test func squareColor() {
+    #expect(Square.a1.color == .dark)
+    #expect(Square.h1.color == .light)
+    #expect(Square.a8.color == .light)
+    #expect(Square.h8.color == .dark)
   }
 
-  func testFileNumber() {
-    XCTAssertEqual(Square.File.a.number, 1)
-    XCTAssertEqual(Square.File.h.number, 8)
+  @Test func fileNumber() {
+    #expect(Square.File.a.number == 1)
+    #expect(Square.File.h.number == 8)
 
-    XCTAssertEqual(Square.File(1), .a)
-    XCTAssertEqual(Square.File(2), .b)
-    XCTAssertEqual(Square.File(3), .c)
-    XCTAssertEqual(Square.File(4), .d)
-    XCTAssertEqual(Square.File(5), .e)
-    XCTAssertEqual(Square.File(6), .f)
-    XCTAssertEqual(Square.File(7), .g)
-    XCTAssertEqual(Square.File(8), .h)
+    #expect(Square.File(1) == .a)
+    #expect(Square.File(2) == .b)
+    #expect(Square.File(3) == .c)
+    #expect(Square.File(4) == .d)
+    #expect(Square.File(5) == .e)
+    #expect(Square.File(6) == .f)
+    #expect(Square.File(7) == .g)
+    #expect(Square.File(8) == .h)
   }
 
-  func testInvalidFileNumber() {
-    XCTAssertEqual(Square.File(-10), .a)
-    XCTAssertEqual(Square.File(100), .h)
+  @Test func invalidFileNumber() {
+    #expect(Square.File(-10) == .a)
+    #expect(Square.File(100) == .h)
   }
 
-  func testDirectionalSquares() {
-    XCTAssertEqual(Square.a1.left, .a1)
-    XCTAssertEqual(Square.b1.left, .a1)
-    XCTAssertEqual(Square.h1.left, .g1)
+  @Test func directionalSquares() {
+    #expect(Square.a1.left == .a1)
+    #expect(Square.b1.left == .a1)
+    #expect(Square.h1.left == .g1)
 
-    XCTAssertEqual(Square.a1.right, .b1)
-    XCTAssertEqual(Square.g1.right, .h1)
-    XCTAssertEqual(Square.h1.right, .h1)
+    #expect(Square.a1.right == .b1)
+    #expect(Square.g1.right == .h1)
+    #expect(Square.h1.right == .h1)
 
-    XCTAssertEqual(Square.a8.up, .a8)
-    XCTAssertEqual(Square.a7.up, .a8)
-    XCTAssertEqual(Square.a1.up, .a2)
+    #expect(Square.a8.up == .a8)
+    #expect(Square.a7.up == .a8)
+    #expect(Square.a1.up == .a2)
 
-    XCTAssertEqual(Square.a1.down, .a1)
-    XCTAssertEqual(Square.a2.down, .a1)
-    XCTAssertEqual(Square.a8.down, .a7)
+    #expect(Square.a1.down == .a1)
+    #expect(Square.a2.down == .a1)
+    #expect(Square.a8.down == .a7)
   }
 
 }


### PR DESCRIPTION
* Migrated all unit tests (except performance tests) from `XCTest` to Swift Testing.
* Added `CustomStringConvertible` conformance to `Piece`, `Piece.Color`, and `Piece.Kind`.