### PR TITLE
Fix en passant parsing in SANParser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# [unreleased]
+
+### Bug Fixes
+* Fix `SANParser` not parsing en passant captures properly (by Rob Raese).
+
+### Deprecations
+* The `enPassantIsPossible` parameter of the `Position` initializer has been deprecated.
+  * This property is automatically set depending on the value of `enPassant` passed to the initializer.
+
 # ChessKit 0.14.0
 Released Tuesday, June 3, 2025.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,6 @@
 ### Bug Fixes
 * Fix `SANParser` not parsing en passant captures properly (by Rob Raese).
 
-### Deprecations
-* The `enPassantIsPossible` parameter of the `Position` initializer has been deprecated.
-  * This property is automatically set depending on the value of `enPassant` passed to the initializer.
-
 # ChessKit 0.14.0
 Released Tuesday, June 3, 2025.
 

--- a/Sources/ChessKit/Parsers/SANParser.swift
+++ b/Sources/ChessKit/Parsers/SANParser.swift
@@ -23,12 +23,12 @@ public enum SANParser {
     guard isValid(san: san) else { return nil }
 
     let color = position.sideToMove
-    var checkstate = Move.CheckState.none
+    var checkState = Move.CheckState.none
 
     if san.contains("#") {
-      checkstate = .checkmate
+      checkState = .checkmate
     } else if san.contains("+") {
-      checkstate = .check
+      checkState = .check
     }
 
     // castling
@@ -46,7 +46,7 @@ public enum SANParser {
         piece: Piece(.king, color: color, square: castling.kingStart),
         start: castling.kingStart,
         end: castling.kingEnd,
-        checkState: checkstate
+        checkState: checkState
       )
     }
 
@@ -73,10 +73,16 @@ public enum SANParser {
 
       var move: Move
 
-      if isCapture(san: san), let capturedPiece = position.piece(at: end) {
-        move = Move(result: .capture(capturedPiece), piece: pawn, start: start, end: capturedPiece.square, checkState: checkstate)
+      if isCapture(san: san) {
+        if let capturedPiece = position.piece(at: end) {
+          move = Move(result: .capture(capturedPiece), piece: pawn, start: start, end: capturedPiece.square, checkState: checkState)
+        } else if let ep = position.enPassant, ep.captureSquare == end {
+          move = Move(result: .capture(ep.pawn), piece: pawn, start: start, end: end, checkState: checkState)
+        } else {
+          move = Move(result: .move, piece: pawn, start: start, end: end, checkState: checkState)
+        }
       } else {
-        move = Move(result: .move, piece: pawn, start: start, end: end, checkState: checkstate)
+        move = Move(result: .move, piece: pawn, start: start, end: end, checkState: checkState)
       }
 
       if let promotionPieceKind = promotionPiece(for: san) {
@@ -122,9 +128,9 @@ public enum SANParser {
         piece.square = end
 
         if isCapture(san: san), let capturedPiece = position.piece(at: end) {
-          move = Move(result: .capture(capturedPiece), piece: piece, start: start, end: end, checkState: checkstate)
+          move = Move(result: .capture(capturedPiece), piece: piece, start: start, end: end, checkState: checkState)
         } else {
-          move = Move(result: .move, piece: piece, start: start, end: end, checkState: checkstate)
+          move = Move(result: .move, piece: piece, start: start, end: end, checkState: checkState)
         }
 
         move?.disambiguation = disambiguation

--- a/Sources/ChessKit/Parsers/SANParser.swift
+++ b/Sources/ChessKit/Parsers/SANParser.swift
@@ -71,22 +71,20 @@ public enum SANParser {
       let start = pawn.square
       pawn.square = end
 
-      var move: Move
+      var move: Move?
 
       if isCapture(san: san) {
         if let capturedPiece = position.piece(at: end) {
           move = Move(result: .capture(capturedPiece), piece: pawn, start: start, end: capturedPiece.square, checkState: checkState)
         } else if let ep = position.enPassant, ep.captureSquare == end {
           move = Move(result: .capture(ep.pawn), piece: pawn, start: start, end: end, checkState: checkState)
-        } else {
-          move = Move(result: .move, piece: pawn, start: start, end: end, checkState: checkState)
         }
       } else {
         move = Move(result: .move, piece: pawn, start: start, end: end, checkState: checkState)
       }
 
       if let promotionPieceKind = promotionPiece(for: san) {
-        move.promotedPiece = Piece(promotionPieceKind, color: color, square: end)
+        move?.promotedPiece = Piece(promotionPieceKind, color: color, square: end)
       }
 
       return move

--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -245,24 +245,6 @@ extension Position: Hashable {
 // MARK: - Deprecated
 extension Position {
 
-  /// Initialize a position with a given array of pieces and characteristics.
-  @available(*, deprecated, message: "Use initializer without `enPassantIsPossible`")
-  init(
-    pieces: [Piece],
-    sideToMove: Piece.Color = .white,
-    legalCastlings: LegalCastlings = LegalCastlings(),
-    enPassant: EnPassant? = nil,
-    enPassantIsPossible: Bool = false,
-    clock: Clock = Clock()
-  ) {
-    self.pieceSet = .init(pieces: pieces)
-    self.sideToMove = sideToMove
-    self.legalCastlings = legalCastlings
-    self.enPassant = enPassant
-    self.enPassantIsPossible = enPassantIsPossible
-    self.clock = clock
-  }
-
   /// Toggle the current side to move.
   @available(*, deprecated, message: "This function no longer has any effect. `sideToMove` is toggled automatically as needed.")
   public mutating func toggleSideToMove() {

--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -40,14 +40,13 @@ public struct Position: Sendable {
     sideToMove: Piece.Color = .white,
     legalCastlings: LegalCastlings = LegalCastlings(),
     enPassant: EnPassant? = nil,
-    enPassantIsPossible: Bool = false,
     clock: Clock = Clock()
   ) {
     self.pieceSet = .init(pieces: pieces)
     self.sideToMove = sideToMove
     self.legalCastlings = legalCastlings
     self.enPassant = enPassant
-    self.enPassantIsPossible = enPassantIsPossible
+    self.enPassantIsPossible = enPassant != nil
     self.clock = clock
   }
 
@@ -65,12 +64,6 @@ public struct Position: Sendable {
   /// Toggle the current side to move.
   private mutating func _toggleSideToMove() {
     sideToMove.toggle()
-  }
-
-  /// Toggle the current side to move.
-  @available(*, deprecated, message: "This function no longer has any effect. `sideToMove` is toggled automatically as needed.")
-  public mutating func toggleSideToMove() {
-
   }
 
   /// Provides the chess piece located at the given square.
@@ -245,6 +238,35 @@ extension Position: Hashable {
     hasher.combine(sideToMove)
     hasher.combine(legalCastlings)
     hasher.combine(enPassantIsPossible)
+  }
+
+}
+
+// MARK: - Deprecated
+extension Position {
+
+  /// Initialize a position with a given array of pieces and characteristics.
+  @available(*, deprecated, message: "Use initializer without `enPassantIsPossible`")
+  init(
+    pieces: [Piece],
+    sideToMove: Piece.Color = .white,
+    legalCastlings: LegalCastlings = LegalCastlings(),
+    enPassant: EnPassant? = nil,
+    enPassantIsPossible: Bool = false,
+    clock: Clock = Clock()
+  ) {
+    self.pieceSet = .init(pieces: pieces)
+    self.sideToMove = sideToMove
+    self.legalCastlings = legalCastlings
+    self.enPassant = enPassant
+    self.enPassantIsPossible = enPassantIsPossible
+    self.clock = clock
+  }
+
+  /// Toggle the current side to move.
+  @available(*, deprecated, message: "This function no longer has any effect. `sideToMove` is toggled automatically as needed.")
+  public mutating func toggleSideToMove() {
+
   }
 
 }

--- a/Tests/ChessKitTests/BoardTests.swift
+++ b/Tests/ChessKitTests/BoardTests.swift
@@ -461,7 +461,6 @@ struct BoardTests {
 }
 
 // MARK: - Deprecated Tests
-
 extension BoardTests {
 
   @available(*, deprecated)

--- a/Tests/ChessKitTests/Parsers/SANParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/SANParserTests.swift
@@ -87,9 +87,10 @@ struct SANParserTests {
   }
 
   @Test func invalidSAN() {
-    #expect(SANParser.parse(move: "e44", in: .standard) == nil)
-    #expect(SANParser.parse(move: "aNf3", in: .standard) == nil)
     #expect(SANParser.parse(move: "bad move", in: .standard) == nil)
+    #expect(SANParser.parse(move: "exf3", in: .standard) == nil)
+    #expect(SANParser.parse(move: "aNf3", in: .standard) == nil)
+    #expect(SANParser.parse(move: "e44", in: .standard) == nil)
   }
 
 }

--- a/Tests/ChessKitTests/Parsers/SANParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/SANParserTests.swift
@@ -18,6 +18,12 @@ struct SANParserTests {
     #expect(longCastle?.result == .castle(.bQ))
   }
 
+  @Test func enPassant() {
+    let p = Position(fen: "rnbqkbnr/pp2pppp/8/2pP4/8/8/PPPP1PPP/RNBQKBNR w KQkq c6 0 1")!
+    let enPassant = SANParser.parse(move: "dxc6", in: p)
+    #expect(enPassant?.result == .capture(.init(.pawn, color: .black, square: .c5)))
+  }
+
   @Test func promotion() {
     let p = Position(fen: "8/P7/8/8/8/8/8/8 w - - 0 1")!
     let promotion = SANParser.parse(move: "a8=Q", in: p)

--- a/Tests/ChessKitTests/PositionTests.swift
+++ b/Tests/ChessKitTests/PositionTests.swift
@@ -8,6 +8,30 @@ import Testing
 
 struct PositionTests {
 
+  @Test func initializer() {
+    let whitePawn = Piece(.pawn, color: .white, square: .e5)
+    let blackPawn = Piece(.pawn, color: .black, square: .d5)
+
+    let position1 = Position(
+      pieces: [whitePawn, blackPawn],
+      sideToMove: .white,
+      legalCastlings: .init(),
+      enPassant: .init(pawn: blackPawn),
+      clock: .init()
+    )
+
+    #expect(position1.enPassantIsPossible)
+
+    let position2 = Position(
+      pieces: [whitePawn, blackPawn],
+      sideToMove: .white,
+      legalCastlings: .init(),
+      clock: .init()
+    )
+
+    #expect(!position2.enPassantIsPossible)
+  }
+
   @Test func sideToMove() {
     var position = Position.standard
     #expect(position.sideToMove == .white)
@@ -37,49 +61,6 @@ extension PositionTests {
     let initialSideToMove = position.sideToMove
     position.toggleSideToMove()
     #expect(initialSideToMove == position.sideToMove)
-  }
-
-  @available(*, deprecated)
-  @Test func legacyPositionInitializer() {
-    let whitePawn = Piece(.pawn, color: .white, square: .e5)
-    let blackPawn = Piece(.pawn, color: .black, square: .d5)
-
-    let legacyPosition1 = Position(
-      pieces: [whitePawn, blackPawn],
-      sideToMove: .white,
-      legalCastlings: .init(),
-      enPassant: .init(pawn: blackPawn),
-      enPassantIsPossible: true,
-      clock: .init()
-    )
-
-    let position1 = Position(
-      pieces: [whitePawn, blackPawn],
-      sideToMove: .white,
-      legalCastlings: .init(),
-      enPassant: .init(pawn: blackPawn),
-      clock: .init()
-    )
-
-    #expect(legacyPosition1 == position1)
-
-    let legacyPosition2 = Position(
-      pieces: [whitePawn, blackPawn],
-      sideToMove: .white,
-      legalCastlings: .init(),
-      enPassant: nil,
-      enPassantIsPossible: false,
-      clock: .init()
-    )
-
-    let position2 = Position(
-      pieces: [whitePawn, blackPawn],
-      sideToMove: .white,
-      legalCastlings: .init(),
-      clock: .init()
-    )
-
-    #expect(legacyPosition2 == position2)
   }
 
 }

--- a/Tests/ChessKitTests/PositionTests.swift
+++ b/Tests/ChessKitTests/PositionTests.swift
@@ -1,0 +1,85 @@
+//
+//  PositionTests.swift
+//  ChessKit
+//
+
+@testable import ChessKit
+import Testing
+
+struct PositionTests {
+
+  @Test func sideToMove() {
+    var position = Position.standard
+    #expect(position.sideToMove == .white)
+
+    position.move(pieceAt: .e2, to: .e4)
+    #expect(position.sideToMove == .black)
+
+    position.move(pieceAt: .e7, to: .e5)
+    #expect(position.sideToMove == .white)
+  }
+
+  @Test func moveNonexistentPieces() {
+    var position = Position.standard
+
+    #expect(position.move(pieceAt: .a3, to: .a4) == nil)
+    #expect(position.move(.init(.pawn, color: .white, square: .a3), to: .a4) == nil)
+  }
+
+}
+
+// MARK: - Deprecated Tests
+extension PositionTests {
+
+  @available(*, deprecated)
+  @Test func positionToggleSideToMove() {
+    var position = Position.standard
+    let initialSideToMove = position.sideToMove
+    position.toggleSideToMove()
+    #expect(initialSideToMove == position.sideToMove)
+  }
+
+  @available(*, deprecated)
+  @Test func legacyPositionInitializer() {
+    let whitePawn = Piece(.pawn, color: .white, square: .e5)
+    let blackPawn = Piece(.pawn, color: .black, square: .d5)
+
+    let legacyPosition1 = Position(
+      pieces: [whitePawn, blackPawn],
+      sideToMove: .white,
+      legalCastlings: .init(),
+      enPassant: .init(pawn: blackPawn),
+      enPassantIsPossible: true,
+      clock: .init()
+    )
+
+    let position1 = Position(
+      pieces: [whitePawn, blackPawn],
+      sideToMove: .white,
+      legalCastlings: .init(),
+      enPassant: .init(pawn: blackPawn),
+      clock: .init()
+    )
+
+    #expect(legacyPosition1 == position1)
+
+    let legacyPosition2 = Position(
+      pieces: [whitePawn, blackPawn],
+      sideToMove: .white,
+      legalCastlings: .init(),
+      enPassant: nil,
+      enPassantIsPossible: false,
+      clock: .init()
+    )
+
+    let position2 = Position(
+      pieces: [whitePawn, blackPawn],
+      sideToMove: .white,
+      legalCastlings: .init(),
+      clock: .init()
+    )
+
+    #expect(legacyPosition2 == position2)
+  }
+
+}


### PR DESCRIPTION
* Fixed en passant parsing in SANParser
* Deprecated `enPassantIsPossible` parameter in `Position` (now initialized internally)
* Added `PositionTests` to handle cases that are not tested by `BoardTests`