### PR TITLE
Parsers bug fixes

### DIFF
--- a/Sources/ChessKit/Parsers/PGNParser/PGNParser+MoveText.swift
+++ b/Sources/ChessKit/Parsers/PGNParser/PGNParser+MoveText.swift
@@ -25,7 +25,27 @@ extension PGNParser {
     // MARK: Private
 
     private static func tokenize(moveText: String) throws(PGNParser.Error) -> [Token] {
-      let inlineMoveText = moveText.components(separatedBy: .newlines).joined(separator: "")
+      var inlineMoveText = moveText.components(separatedBy: .newlines).joined(separator: "")
+        
+      var resultToken: Token? = nil
+      var moves = inlineMoveText.components(separatedBy: .whitespaces)
+      
+      if let resultMove = moves.popLast() {
+        var isValidResult = true
+        for c in resultMove {
+          isValidResult = TokenType.result.isValid(character: c)
+          if !isValidResult {
+            break
+          }
+        }
+          
+        if isValidResult,
+          let token = TokenType.result.convert(resultMove) {
+          resultToken = token
+          inlineMoveText = moves.joined(separator: " ")
+        }
+      }
+        
       var iterator = inlineMoveText.makeIterator()
 
       var tokens = [Token]()
@@ -59,6 +79,10 @@ extension PGNParser {
 
       if !currentToken.isEmpty, let token = currentTokenType.convert(currentToken) {
         tokens.append(token)
+      }
+        
+      if let resultToken {
+        tokens.append(resultToken)
       }
 
       return tokens

--- a/Sources/ChessKit/Parsers/PGNParser/PGNParser+MoveText.swift
+++ b/Sources/ChessKit/Parsers/PGNParser/PGNParser+MoveText.swift
@@ -246,7 +246,7 @@ private extension PGNParser.MoveTextParser {
     }
 
     static func isResult(_ character: Character) -> Bool {
-      ["1", "2", "/", "-", "0", "*"].contains(character)
+      ["1", "2", "/", "-", "0", "*", "½"].contains(character)
     }
 
     func isValid(character: Character) -> Bool {

--- a/Sources/ChessKit/Parsers/SANParser+Regex.swift
+++ b/Sources/ChessKit/Parsers/SANParser+Regex.swift
@@ -18,7 +18,7 @@ extension SANParser {
     static let longCastle = #"^[Oo0]-[Oo0]-[Oo0]\+?#?$"#
 
     // disambiguation
-    static let disambiguation = #"[a-h]?[1-8]?(?=([a-h][1-8])$)"#
+    static let disambiguation = #"[a-h]?[1-8]?(?=([a-h][1-8][#+]?)$)"#
     static let rank = #"^[1-8]$"#
     static let file = #"^[a-h]$"#
     static let square = #"^[a-h][1-8]$"#

--- a/Tests/ChessKitTests/Parsers/PGNParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/PGNParserTests.swift
@@ -47,6 +47,11 @@ struct PGNParserTests {
     #expect(game.tags.termination == "normal")
     #expect(game.tags.mode == "OTB")
   }
+    
+  @Test func tagResultWinParsing() throws {
+    let game = try PGNParser.parse(game: Game.byrneFischer)
+    #expect(game.tags.result == "0-1")
+  }
 
   @Test func tagParsingIrregularWhitespace() throws {
     let game = try PGNParser.parse(

--- a/Tests/ChessKitTests/Parsers/SANParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/SANParserTests.swift
@@ -52,6 +52,7 @@ struct SANParserTests {
   @Test func disambiguation() {
     let pw = Position(fen: "3r3r/8/8/R7/4Q2Q/8/8/R6Q w - - 0 1")!
     let pb = Position(fen: "3r3r/8/8/R7/4Q2Q/8/8/R6Q b - - 0 1")!
+    let pbCheck = Position(fen: "r4rk1/pp3pbp/1qp3p1/2B5/2BP2b1/Q1n2N2/P4PPP/3RK2R b K - 1 16")!
 
     let rookFileMove = SANParser.parse(move: "R1a3", in: pw)
     #expect(rookFileMove?.result == .move)
@@ -70,6 +71,15 @@ struct SANParserTests {
     #expect(rookRankMove?.end == .f8)
     #expect(rookRankMove?.promotedPiece == nil)
     #expect(rookRankMove?.checkState == Move.CheckState.none)
+      
+    let rookCheckMove = SANParser.parse(move: "Rfe8+", in: pbCheck)
+    #expect(rookCheckMove?.result == .move)
+    #expect(rookCheckMove?.piece.kind == .rook)
+    #expect(rookCheckMove?.disambiguation == .byFile(.f))
+    #expect(rookCheckMove?.start == .f8)
+    #expect(rookCheckMove?.end == .e8)
+    #expect(rookCheckMove?.promotedPiece == nil)
+    #expect(rookCheckMove?.checkState == Move.CheckState.check)
 
     let queenMove = SANParser.parse(move: "Qh4e1", in: pw)
     #expect(queenMove?.result == .move)

--- a/Tests/ChessKitTests/Utilities/SampleGames.swift
+++ b/Tests/ChessKitTests/Utilities/SampleGames.swift
@@ -34,4 +34,23 @@ extension Game {
     35. Ra7 g6 36. Ra6+ Kc5 37. Ke1 Nf4 38. g3 Nxh3 39. Kd2 Kb5 40. Rd6 Kc5 41. Ra6
     Nf2 42. g4 Bd3 43. Re6 1/2-1/2
     """
+    
+  static let byrneFischer =
+    """
+    [Event "Third Rosenwald Trophy"]
+    [Site "New York, NY USA"]
+    [Date "1956.10.17"]
+    [EventDate "1956.10.07"]
+    [Round "8"]
+    [Result "0-1"]
+    [White "Donald Byrne"]
+    [Black "Robert James Fischer"]
+    [ECO "D92"]
+    [WhiteElo "?"]
+    [BlackElo "?"]
+    [PlyCount "82"]
+
+    1.Nf3 Nf6 2.c4 g6 3.Nc3 Bg7 4.d4 0-0 5.Bf4 d5 6.Qb3 dxc4 7.Qxc4 c6 8.e4 Nbd7 9.Rd1 Nb6 10.Qc5 Bg4 11.Bg5 Na4 12.Qa3 Nxc3 13.bxc3 Nxe4 14.Bxe7 Qb6 15.Bc4 Nxc3 16.Bc5 Rfe8+ 17.Kf1 Be6 18.Bxb6 Bxc4+ 19.Kg1 Ne2+ 20.Kf1 Nxd4+ 21.Kg1 Ne2+ 22.Kf1 Nc3+ 23.Kg1 axb6 24.Qb4 Ra4 25.Qxb6 Nxd1 26.h3 Rxa2 27.Kh2 Nxf2 28.Re1 Rxe1 29.Qd8+ Bf8 30.Nxe1 Bd5 31.Nf3 Ne4 32.Qb8 b5 33.h4 h5 34.Ne5 Kg7 35.Kg1 Bc5+ 36.Kf1 Ng3+ 37.Ke1 Bb4+ 38.Kd1 Bb3+ 39.Kc1 Ne2+ 40.Kb1 Nc3+ 41.Kc1 Rc2# 0-1
+    """
+
 }

--- a/Tests/ChessKitTests/Utilities/SampleGames.swift
+++ b/Tests/ChessKitTests/Utilities/SampleGames.swift
@@ -50,7 +50,7 @@ extension Game {
     [BlackElo "?"]
     [PlyCount "82"]
 
-    1.Nf3 Nf6 2.c4 g6 3.Nc3 Bg7 4.d4 0-0 5.Bf4 d5 6.Qb3 dxc4 7.Qxc4 c6 8.e4 Nbd7 9.Rd1 Nb6 10.Qc5 Bg4 11.Bg5 Na4 12.Qa3 Nxc3 13.bxc3 Nxe4 14.Bxe7 Qb6 15.Bc4 Nxc3 16.Bc5 Rfe8+ 17.Kf1 Be6 18.Bxb6 Bxc4+ 19.Kg1 Ne2+ 20.Kf1 Nxd4+ 21.Kg1 Ne2+ 22.Kf1 Nc3+ 23.Kg1 axb6 24.Qb4 Ra4 25.Qxb6 Nxd1 26.h3 Rxa2 27.Kh2 Nxf2 28.Re1 Rxe1 29.Qd8+ Bf8 30.Nxe1 Bd5 31.Nf3 Ne4 32.Qb8 b5 33.h4 h5 34.Ne5 Kg7 35.Kg1 Bc5+ 36.Kf1 Ng3+ 37.Ke1 Bb4+ 38.Kd1 Bb3+ 39.Kc1 Ne2+ 40.Kb1 Nc3+ 41.Kc1 Rc2# 0-1
+    1.Nf3 Nf6 2.c4 g6 3.Nc3 Bg7 4.d4 O-O 5.Bf4 d5 6.Qb3 dxc4 7.Qxc4 c6 8.e4 Nbd7 9.Rd1 Nb6 10.Qc5 Bg4 11.Bg5 Na4 12.Qa3 Nxc3 13.bxc3 Nxe4 14.Bxe7 Qb6 15.Bc4 Nxc3 16.Bc5 Rfe8+ 17.Kf1 Be6 18.Bxb6 Bxc4+ 19.Kg1 Ne2+ 20.Kf1 Nxd4+ 21.Kg1 Ne2+ 22.Kf1 Nc3+ 23.Kg1 axb6 24.Qb4 Ra4 25.Qxb6 Nxd1 26.h3 Rxa2 27.Kh2 Nxf2 28.Re1 Rxe1 29.Qd8+ Bf8 30.Nxe1 Bd5 31.Nf3 Ne4 32.Qb8 b5 33.h4 h5 34.Ne5 Kg7 35.Kg1 Bc5+ 36.Kf1 Ng3+ 37.Ke1 Bb4+ 38.Kd1 Bb3+ 39.Kc1 Ne2+ 40.Kb1 Nc3+ 41.Kc1 Rc2# 0-1
     """
 
 }


### PR DESCRIPTION
After updating to the latest version (0.15.0) I found some bugs, which I've addressed in this PR. 

1. 
A decisive game that ends in a victory to either side is being tokenized as a number. 
This causes issues later on while parsing the tokens causing the parse to fail. 

Root cause: 
while tokenizing the pgn moves, when we reach the game result the match function checks for "isNumber" before we check for result or san which a "0" or "1" are both return that they are valid numbers, the next iteration checks for "-" character which is not a valid number character, therefore we assume we have a complete token, add it to the tokens array and match the new character with san token.

If we try to parse the result at the same time as other moves, we are guaranteed to match to a number or san tokens. 

This is also true for `tagParsing()` test, but since /2-1/2 is parse to result token and the 1 is parsed to number and both number and results are ignored while parsing, this test passes.

Solution : 
Check if a result token exists before tokenizing moves and if it does, remove it from inlineMoveText and append it to the tokens array after tokenizing moves (since it's ignored at parsing phase, this can also be dropped altogether).

------------------------

2. 
Added ½ character as a supported character for result token as some online sites use it to mark a draw (Not sure, but I think chess.com does)

No tests were added for this as it's currently dropped during parsing phase

------------------------

3. 
Move disambiguation regex check fails for moves that result in check or checkmate

Solution:
added "+" and "#" as optional characters to the regex 


P.S., 
I've also added support to pgn castling for using zeros instead of capital Os. 
Although not supported by SAN/PGN, it is a legal castling character according to the FIDE handbook. 

Not sure you'd like to allow it but if you do, let me know and I will open a separate PR for that. 

Cheers! 