### PR TITLE
Replace `BoardDelegate` with `Board.State`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [unreleased]
+
+### New Features
+* Add `Board.state` property to track board state changes.
+  * `BoardDelegate` and `Board.delegate` have been deprecated and will be removed in the future.
+* Add `Board.update(position:)` to update `position` in `Board`.
+  * Updates `state` along with `position`.
+
 # ChessKit 0.15.0
 Released Thursday, June 19, 2025.
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,25 @@ let board = Board()
 print(board.legalMoves(forPieceAt: .e2))    // [.e3, .e4]
 ```
 
+* Check board state after making a move
+``` swift
+let board = Board(position: .init("8/5K1k/8/4Q3/8/8/8/8 w - - 0 1")!)
+print(board.state) // .active (default)
+
+// 8 · · · · · · · ·
+// 7 · · · · · ♔ · ♚
+// 6 · · · · · · · ·
+// 5 · · · · ♕ · · ·
+// 4 · · · · · · · ·
+// 3 · · · · · · · ·
+// 2 · · · · · · · ·
+// 1 · · · · · · · ·
+//   a b c d e f g h
+
+board.move(pieceAt: "e5", to: "g7")
+print(board.state) // .checkmate(color: .black)
+```
+
 * Parse [FEN](https://en.wikipedia.org/wiki/Forsyth–Edwards_Notation) into a `Position` object, [PGN](https://en.wikipedia.org/wiki/Portable_Game_Notation) (into `Game`), or [SAN](https://en.wikipedia.org/wiki/Algebraic_notation_(chess)) (into `Move`).
 ``` swift
 // parse FEN using Position initializer

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -664,7 +664,7 @@ extension Board {
   public enum State: Hashable, Sendable {
     /// The board's position represents an active position.
     ///
-    /// This value indicates there is nothing of note about this position.
+    /// This default state indicates there is nothing of note about this position.
     case active
     /// The board's position represents an active piece promotion
     /// with the given move.
@@ -674,8 +674,14 @@ extension Board {
     /// the promotion.
     case promotion(move: Move)
     /// The board's position represents a check on the given `color`.
+    ///
+    /// To get the color of the piece that executed the check
+    /// use ``Piece/Color/opposite``.
     case check(color: Piece.Color)
     /// The board's position represents a checkmate on the given `color`.
+    ///
+    /// To get the color of the piece that executed the checkmate
+    /// use ``Piece/Color/opposite``.
     case checkmate(color: Piece.Color)
     /// The board's position represents a draw with a given `reason`.
     case draw(reason: DrawReason)

--- a/Sources/ChessKit/BoardDelegate.swift
+++ b/Sources/ChessKit/BoardDelegate.swift
@@ -1,0 +1,23 @@
+//
+//  BoardDelegate.swift
+//  ChessKit
+//
+
+/// Delegate protocol that allows the implementer to receive
+/// events related to changes in position on the board such
+/// as pawn promotions and end results.
+@available(*, deprecated, message: "Monitor `state` property of `Board` instead.")
+public protocol BoardDelegate: AnyObject, Sendable {
+  /// Called when a pawn reaches the promotion square.
+  func willPromote(with move: Move)
+  /// Called after a pawn has promoted to a new `Piece.Kind`.
+  ///
+  /// `move` will have its `promotedPiece` set when this is called.
+  func didPromote(with move: Move)
+  /// Called when the king with `color` is placed in check.
+  func didCheckKing(ofColor color: Piece.Color)
+  /// Called when the board has reached an end state.
+  ///
+  /// For example, checkmate, stalemate, etc.
+  func didEnd(with result: Board.EndResult)
+}

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -37,12 +37,13 @@ public struct Game: Hashable, Sendable {
   ///
   /// Defaults to the starting position.
   public init(startingWith position: Position = .standard, tags: Tags? = nil) {
-    moves = MoveTree()
     let startingIndex = position.sideToMove == .white ? MoveTree.Index.minimum : .minimum.next
     self.startingIndex = startingIndex
+    
     positions = [startingIndex: position]
     self.tags = tags ?? .init()
 
+    moves = .init()
     moves.minimumIndex = startingIndex
   }
 
@@ -52,11 +53,7 @@ public struct Game: Hashable, Sendable {
   /// a game.
   public init(pgn: String) throws {
     let parsed = try PGNParser.parse(game: pgn)
-
-    moves = parsed.moves
-    startingIndex = .minimum
-    positions = parsed.positions
-    tags = parsed.tags
+    self = parsed
   }
 
   // MARK: Moves

--- a/Sources/ChessKit/Move.swift
+++ b/Sources/ChessKit/Move.swift
@@ -39,6 +39,9 @@ public struct Move: Hashable, Sendable {
   /// The result of the move.
   public internal(set) var result: Result
   /// The piece that made the move.
+  ///
+  /// - warning: Do not refer to this piece's `square` directly,
+  /// use the move's `start` and `end` properties as needed.
   public internal(set) var piece: Piece
   /// The starting square of the move.
   public internal(set) var start: Square

--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -41,9 +41,9 @@ public struct Position: Sendable {
   init(
     pieces: [Piece],
     sideToMove: Piece.Color = .white,
-    legalCastlings: LegalCastlings = LegalCastlings(),
+    legalCastlings: LegalCastlings = .init(),
     enPassant: EnPassant? = nil,
-    clock: Clock = Clock(),
+    clock: Clock = .init(),
     assessment: Assessment = .null
   ) {
     self.pieceSet = .init(pieces: pieces)

--- a/Tests/ChessKitTests/Parsers/PGNParserTests.swift
+++ b/Tests/ChessKitTests/Parsers/PGNParserTests.swift
@@ -9,14 +9,14 @@ import Testing
 struct PGNParserTests {
 
   @Test func gameFromEmptyPGN() throws {
-    #expect(try PGNParser.parse(game: "") == .init(startingWith: .standard))
+    #expect(try PGNParser.parse(game: "").pgn == Game(startingWith: .standard).pgn)
   }
 
   @Test func gameFromPGN() throws {
     let game = try PGNParser.parse(game: Game.fischerSpassky)
     let gameFromPGN = try Game(pgn: Game.fischerSpassky)
 
-    #expect(game == gameFromPGN)
+    #expect(game.pgn == gameFromPGN.pgn)
   }
 
   @Test func pgnFromGame() {
@@ -230,7 +230,7 @@ extension PGNParserTests {
     let pgn = Game.fischerSpassky.replacingOccurrences(of: "$135 ", with: "")
 
     #expect(
-      try PGNParser.parse(game: pgn) == PGNParser.parse(game: pgn, startingWith: .standard)
+      try PGNParser.parse(game: pgn).pgn == PGNParser.parse(game: pgn, startingWith: .standard).pgn
     )
   }
 

--- a/Tests/ChessKitTests/Utilities/MockBoardDelegate.swift
+++ b/Tests/ChessKitTests/Utilities/MockBoardDelegate.swift
@@ -5,6 +5,7 @@
 
 import ChessKit
 
+@available(*, deprecated)
 final class MockBoardDelegate: BoardDelegate {
   private let willPromote: (@Sendable (Move) -> Void)?
   private let didPromote: (@Sendable (Move) -> Void)?


### PR DESCRIPTION
* `BoardDelegate` has been deprecated and will be removed in the future (most likely at version 1.0)
* `state` property of type `Board.State` has been added to `Board`
* After making a move on `Board`, the `state` property is updated with an information of note, i.e. checks, checkmates, draw conditions, and promotions