### PR TITLE
Codable conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [unreleased]
+
+### New Features
+* All public types except for `Board` now conform to `Codable`.
+  * `Board` conformance to `Codable` will be added when `BoardDelegate` is removed.
+
 # ChessKit 0.16.0
 Released Monday, September 15, 2025.
 

--- a/Sources/ChessKit/Bitboards/PieceSet.swift
+++ b/Sources/ChessKit/Bitboards/PieceSet.swift
@@ -7,7 +7,7 @@
 ///
 /// Also contains convenient amalgamations
 /// of different combinations of pieces.
-struct PieceSet: Hashable, Sendable {
+struct PieceSet: Codable, Hashable, Sendable {
   /// Bitboard for black king pieces.
   var k: Bitboard = 0
   /// Bitboard for black queen pieces.

--- a/Sources/ChessKit/Board.swift
+++ b/Sources/ChessKit/Board.swift
@@ -663,7 +663,7 @@ public struct Board: Sendable {
 // MARK: - State
 extension Board {
   /// Represents a state of the board.
-  public enum State: Hashable, Sendable {
+  public enum State: Codable, Hashable, Sendable {
     /// The board's position represents an active position.
     ///
     /// This default state indicates there is nothing of note about this position.
@@ -689,7 +689,7 @@ extension Board {
     case draw(reason: DrawReason)
 
     /// The type of draw represented on the board.
-    public enum DrawReason: String, Sendable {
+    public enum DrawReason: String, Codable, Sendable {
       case agreement
       case fiftyMoves
       case insufficientMaterial

--- a/Sources/ChessKit/Clock.swift
+++ b/Sources/ChessKit/Clock.swift
@@ -5,7 +5,7 @@
 
 /// Tracks the number of moves in a game for
 /// the purposes of regulating the 50 move rule.
-public struct Clock: Hashable, Sendable {
+public struct Clock: Codable, Hashable, Sendable {
 
   /// The maximum number of half moves before
   /// a draw by the fifty move rule should be called.

--- a/Sources/ChessKit/Configuration.swift
+++ b/Sources/ChessKit/Configuration.swift
@@ -4,13 +4,13 @@
 //
 
 /// Stores configuration options for the `ChessKit` package.
-public struct ChessKitConfiguration: Sendable {
+public struct ChessKitConfiguration: Codable, Sendable {
 
   /// Configuration options for printing ``Board`` and ``Position`` objects, useful
   /// for debugging.
   public nonisolated(unsafe) static var printOptions = PrintOptions()
 
-  public struct PrintOptions: Sendable {
+  public struct PrintOptions: Codable, Sendable {
     /// Whether to print pieces as letters (`letter`) or unicode graphics (`graphic`)
     /// when printing ``Board`` and ``Position`` objects.
     ///
@@ -24,7 +24,7 @@ public struct ChessKitConfiguration: Sendable {
     public var showCoordinates = true
 
     /// ChessKit `printMode` options.
-    public enum PrintMode: Sendable {
+    public enum PrintMode: Codable, Sendable {
       /// Print pieces as unicode graphic characters, e.g. ♟, ♞, ♝, ♜, ♛, ♚.
       case graphic
       /// Print pieces as FEN letters, e.g. P, N, B, R, Q, K.

--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -10,7 +10,7 @@ import Foundation
 /// This object is the entry point for interacting with a full
 /// chess game within `ChessKit`. It provides methods for
 /// making moves and publishes the played moves in an observable way.
-public struct Game: Hashable, Sendable {
+public struct Game: Codable, Hashable, Sendable {
 
   // MARK: Properties
 
@@ -220,7 +220,7 @@ extension Game {
 
   /// Represents a PGN tag pair.
   @propertyWrapper
-  public struct Tag: Hashable, Sendable {
+  public struct Tag: Codable, Hashable, Sendable {
 
     /// The name of the tag pair.
     ///
@@ -246,7 +246,7 @@ extension Game {
   }
 
   /// Contains the PGN tag pairs for a game.
-  public struct Tags: Hashable, Sendable {
+  public struct Tags: Codable, Hashable, Sendable {
 
     /// Returns all named tags.
     ///

--- a/Sources/ChessKit/Move.swift
+++ b/Sources/ChessKit/Move.swift
@@ -4,17 +4,17 @@
 //
 
 /// Represents a move on a chess board.
-public struct Move: Hashable, Sendable {
+public struct Move: Codable, Hashable, Sendable {
 
   /// The result of the move.
-  public enum Result: Hashable, Sendable {
+  public enum Result: Codable, Hashable, Sendable {
     case move
     case capture(Piece)
     case castle(Castling)
   }
 
   /// The check state resulting from the move.
-  public enum CheckState: String, Sendable {
+  public enum CheckState: String, Codable, Sendable {
     case none
     case check
     case checkmate
@@ -30,7 +30,7 @@ public struct Move: Hashable, Sendable {
   }
 
   /// Rank, file, or square disambiguation of moves.
-  public enum Disambiguation: Hashable, Sendable {
+  public enum Disambiguation: Codable, Hashable, Sendable {
     case byFile(Square.File)
     case byRank(Square.Rank)
     case bySquare(Square)
@@ -110,7 +110,7 @@ extension Move {
   ///
   /// The raw String value corresponds to what is displayed
   /// in a PGN string.
-  public enum Assessment: String, Sendable {
+  public enum Assessment: String, Codable, Sendable {
     case null = "$0"
     case good = "$1"
     case mistake = "$2"

--- a/Sources/ChessKit/MoveTree/MoveTree+Index.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree+Index.swift
@@ -5,7 +5,7 @@
 
 extension MoveTree {
   /// Object that represents the index of a node in the move tree.
-  public struct Index: Hashable, Sendable {
+  public struct Index: Codable, Hashable, Sendable {
 
     /// Variation number corresponding to the main variation of the tree.
     public static let mainVariation = 0

--- a/Sources/ChessKit/MoveTree/MoveTree.swift
+++ b/Sources/ChessKit/MoveTree/MoveTree.swift
@@ -9,7 +9,7 @@ import Foundation
 ///
 /// The tree maintains the move order including variations and
 /// provides index-based access for any element in the tree.
-public struct MoveTree: Hashable, Sendable {
+public struct MoveTree: Codable, Hashable, Sendable {
 
   /// The index of the root of the move tree.
   ///
@@ -374,7 +374,7 @@ extension MoveTree: Equatable {
 extension MoveTree {
 
   /// Object that represents a node in the move tree.
-  class Node: Hashable, @unchecked Sendable, Sequence {
+  class Node: Codable, Hashable, @unchecked Sendable, Sequence {
 
     /// The move for this node.
     var move: Move

--- a/Sources/ChessKit/Piece.swift
+++ b/Sources/ChessKit/Piece.swift
@@ -4,10 +4,10 @@
 //
 
 /// Represents a piece on the chess board.
-public struct Piece: Hashable, Sendable {
+public struct Piece: Codable, Hashable, Sendable {
 
   /// Represents the color of a piece.
-  public enum Color: String, CaseIterable, Sendable {
+  public enum Color: String, CaseIterable, Codable, Sendable {
     case black = "b", white = "w"
 
     /// The opposite color of the given color.
@@ -22,7 +22,7 @@ public struct Piece: Hashable, Sendable {
   }
 
   /// Represents the type of piece.
-  public enum Kind: String, CaseIterable, Sendable {
+  public enum Kind: String, CaseIterable, Codable, Sendable {
     case pawn = ""
     case knight = "N", bishop = "B", rook = "R", queen = "Q", king = "K"
 

--- a/Sources/ChessKit/Position.swift
+++ b/Sources/ChessKit/Position.swift
@@ -4,7 +4,7 @@
 //
 
 /// Represents the collection of pieces on the chess board.
-public struct Position: Sendable {
+public struct Position: Codable, Sendable {
 
   /// The pieces currently existing on the board in this position.
   public var pieces: [Piece] {
@@ -215,7 +215,7 @@ extension Position {
   ///
   /// The raw String value corresponds to what is displayed
   /// in a PGN string.
-  public enum Assessment: String, Sendable {
+  public enum Assessment: String, Codable, Sendable {
     case null = ""
     case drawishPosition = "$10"
     case equalChancesQuietPosition = "$11"

--- a/Sources/ChessKit/Special Moves/Castling.swift
+++ b/Sources/ChessKit/Special Moves/Castling.swift
@@ -4,7 +4,7 @@
 //
 
 /// Structure that captures legal castling moves.
-struct LegalCastlings: Hashable, Sendable {
+struct LegalCastlings: Codable, Hashable, Sendable {
 
   private var legal: [Castling]
 
@@ -55,7 +55,7 @@ struct LegalCastlings: Hashable, Sendable {
 ///
 /// Contains various characteristics of the castling move
 /// such as king and rook start and end squares and notation.
-public struct Castling: Hashable, Sendable {
+public struct Castling: Codable, Hashable, Sendable {
 
   /// Kingside castle for black.
   static let bK = Castling(side: .king, color: .black)
@@ -68,7 +68,7 @@ public struct Castling: Hashable, Sendable {
 
   /// Represents the side of the board from which castling an occur.
   /// Either `king` or `queen`.
-  enum Side: CaseIterable, Sendable {
+  enum Side: CaseIterable, Codable, Sendable {
     case king, queen
 
     var notation: String {

--- a/Sources/ChessKit/Special Moves/EnPassant.swift
+++ b/Sources/ChessKit/Special Moves/EnPassant.swift
@@ -4,7 +4,7 @@
 //
 
 /// Structure that captures en passant moves.
-struct EnPassant: Hashable, Sendable {
+struct EnPassant: Codable, Hashable, Sendable {
 
   /// Pawn that is capable of being captured by en passant.
   var pawn: Piece

--- a/Sources/ChessKit/Square.swift
+++ b/Sources/ChessKit/Square.swift
@@ -4,9 +4,9 @@
 //
 
 /// Represents a square on the chess board.
-public enum Square: Int, CaseIterable, Sendable {
+public enum Square: Int, CaseIterable, Codable, Sendable {
   /// The file on the chess board, from a to h.
-  public enum File: String, CaseIterable, Sendable {
+  public enum File: String, CaseIterable, Codable, Sendable {
     case a, b, c, d, e, f, g, h
 
     /// The number corresponding to the file.
@@ -46,7 +46,7 @@ public enum Square: Int, CaseIterable, Sendable {
   }
 
   /// The rank on the chess board, from 1 to 8.
-  public struct Rank: ExpressibleByIntegerLiteral, Hashable, Sendable {
+  public struct Rank: Codable, ExpressibleByIntegerLiteral, Hashable, Sendable {
     /// The possible range of Rank numbers.
     public static let range = 1...8
 

--- a/Tests/ChessKitTests/Performance/BoardPerformanceTests.swift
+++ b/Tests/ChessKitTests/Performance/BoardPerformanceTests.swift
@@ -9,6 +9,12 @@ import XCTest
 final class BoardPerformanceTests: XCTestCase {
 
   func testBoardPerformance() {
+    // Clock Monotonic Time: 0.014 s
+    // CPU Cycles: 35461.259 kC
+    // CPU Instructions Retired: 141907.174 kI
+    // CPU Time: 0.014 s
+    // Memory Peak Physical: 36245.299 kB
+    // Memory Physical: 13.107 kB
     measure(
       metrics: [
         XCTClockMetric(),


### PR DESCRIPTION
Enabled `Codable` conformance for all public types (except `Board`). This allows objects derived from `ChessKit` to be encoded/decoded for storage or network transmission.

#### `Board` conformance to Codable
`Board` conformance will be enabled once `BoardDelegate` is removed completely. Until then, `Board.position` and `Board.state` can be encoded/decoded instead as a reasonable proxy. 

> [!note]
Using `position`/`state` alone will lack the position count information used to calculate threefold repetition.