### PR TITLE
Fix disambiguation regex for rank-disambiguated captures (e.g. R7xf6)

### DIFF
--- a/Sources/ChessKit/Parsers/SANParser+Regex.swift
+++ b/Sources/ChessKit/Parsers/SANParser+Regex.swift
@@ -18,7 +18,7 @@ extension SANParser {
     static let longCastle = #"^[Oo0]-[Oo0]-[Oo0]\+?#?$"#
 
     // disambiguation
-    static let disambiguation = #"[a-h]?[1-8]?(?=([a-h][1-8][#+]?)$)"#
+    static let disambiguation = #"[a-h]?[1-8]?(?=(x?[a-h][1-8][#+]?)$)"#
     static let rank = #"^[1-8]$"#
     static let file = #"^[a-h]$"#
     static let square = #"^[a-h][1-8]$"#


### PR DESCRIPTION
The lookahead in the disambiguation pattern did not account for the capture character 'x', causing rank-disambiguated captures like R7xf6 to not be recognized. This left the wrong rook in place, corrupting the position for all subsequent moves.

Fix: add x? to the lookahead pattern.

Reported in: https://github.com/chesskit-app/chesskit-swift/issues/75