### PR TITLE
Fix en passant not set when parsing PGN via Game.make(move:from:)

### DIFF
--- a/Sources/ChessKit/Game.swift
+++ b/Sources/ChessKit/Game.swift
@@ -99,7 +99,24 @@ public struct Game: Codable, Hashable, Sendable {
     switch move.result {
     case .move:
       newPosition.move(pieceAt: move.start, to: move.end)
-      if move.piece.kind == .pawn { newPosition.resetHalfmoveClock() }
+      if move.piece.kind == .pawn {
+        newPosition.resetHalfmoveClock()
+        // Set en passant if pawn advances two squares,
+        // so the next position knows a capture is possible.
+        if abs(move.start.rank.value - move.end.rank.value) == 2,
+           let movedPawn = newPosition.piece(at: move.end) {
+          newPosition.enPassant = EnPassant(pawn: movedPawn)
+          newPosition.enPassantIsPossible = true
+        } else {
+          // Clear en passant — pawn moved only one square.
+          newPosition.enPassant = nil
+          newPosition.enPassantIsPossible = false
+        }
+      } else {
+        // Non-pawn move — clear en passant.
+        newPosition.enPassant = nil
+        newPosition.enPassantIsPossible = false
+      }
     case let .capture(capturedPiece):
       newPosition.remove(capturedPiece)
       newPosition.move(pieceAt: move.start, to: move.end)


### PR DESCRIPTION
Game.make(move:from:) was not updating enPassant on the new position when a pawn advanced two squares. This caused the subsequent position to have no knowledge of the en passant possibility, making SANParser fail to find a legal pawn capture (e.g. cxd6) and throwing PGNParser.Error.invalidMove.

Board.move() handled this correctly — Game.make() now mirrors that behavior by setting enPassant and enPassantIsPossible when a pawn moves two squares, and clearing them otherwise.