### PR TITLE
Fix castling with check not recognized in SAN validation regex

### DIFF
--- a/Sources/ChessKit/Parsers/SANParser+Regex.swift
+++ b/Sources/ChessKit/Parsers/SANParser+Regex.swift
@@ -7,7 +7,7 @@ extension SANParser {
 
   /// Contains useful regex strings for SAN parsing.
   struct Pattern {
-    static let full = #"^([Oo0]-[Oo0](-[Oo0])?|[KQRBN]?[a-h]?[1-8]?x?[a-h][1-8](\=[QRBN])?[+#]?)$"#
+    static let full = #"^([Oo0]-[Oo0](-[Oo0])?[+#]?|[KQRBN]?[a-h]?[1-8]?x?[a-h][1-8](\=[QRBN])?[+#]?)$"#
 
     // piece kinds
     static let pawnFile = #"^[a-h]"#


### PR DESCRIPTION
The full SAN validation regex did not include [+#]? after the castling pattern, causing moves like O-O-O+ and O-O+ to fail isValid() before reaching the castling logic in SANParser.parse(move:in:).

Fix: add [+#]? to the castling portion of the full pattern.